### PR TITLE
Upgrades: upgrade to latest version of redux

### DIFF
--- a/app/javascript/src/_common/create_merged_reducer.ts
+++ b/app/javascript/src/_common/create_merged_reducer.ts
@@ -19,7 +19,7 @@ function initState(reducerMap) {
 
 function createMergedReducer(reducerMap) {
   return function mergedReducer(previousState, action) {
-    if (action.type === '@@redux/INIT') { return initState(reducerMap); }
+    if (action.type.startsWith('@@redux/INIT')) { return initState(reducerMap); }
 
     const reducerKey = getReducerKey(action);
     const reducer = grab(reducerMap, reducerKey);

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-modal": "^3.0.0",
     "react-redux": "^5.0.6",
     "react-textarea-autosize": "^6.1.0",
-    "redux": "^3.7.2",
+    "redux": "^4.0.0",
     "redux-thunk": "^2.2.0",
     "reqwest": "*",
     "reselect": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7104,7 +7104,7 @@ redux-thunk@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
 
-redux@^3.7.1, redux@^3.7.2:
+redux@^3.7.1:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:
@@ -7112,6 +7112,13 @@ redux@^3.7.1, redux@^3.7.2:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
+
+redux@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
+  dependencies:
+    loose-envify "^1.1.0"
+    symbol-observable "^1.2.0"
 
 regenerate@^1.2.1:
   version "1.4.0"
@@ -8159,7 +8166,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.3:
+symbol-observable@^1.0.3, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
This is to hopefully fix some TypeScript issues.

They tacked on a random string to the `@@redux/INIT` action type because
they consider it to be an internal implementation detail. For now we
just check that it starts with this, but we'll examine alternatives
later.