### PR TITLE
CI: add */* to HtmlConstraint

### DIFF
--- a/lib/html_constraint.rb
+++ b/lib/html_constraint.rb
@@ -1,12 +1,9 @@
 class HtmlConstraint
 
   def matches?(request)
-    accept_format(request).include?('text/html')
-  end
-
-  def accept_format(request)
     # not all request headers have an 'Accept', so we default to 'text/html'
-    request.headers['Accept'] || 'text/html'
+    accept_format = request.headers['Accept'] || 'text/html'
+    accept_format.include?('text/html') || accept_format.include?('*/*')
   end
 
 end

--- a/spec/lib/html_constraint_spec.rb
+++ b/spec/lib/html_constraint_spec.rb
@@ -1,0 +1,30 @@
+RSpec.describe HtmlConstraint, '#matches?' do
+
+  let(:constraint) { described_class.new }
+  let(:request) { OpenStruct.new(headers: {}) }
+
+  it 'returns true when format has "text/html"' do
+    request.headers['Accept'] = 'footext/htmlbar'
+    expect(constraint.matches?(request)).to be true
+  end
+
+  it 'returns true when format has "*/*"' do
+    request.headers['Accept'] = 'foo*/*bar'
+    expect(constraint.matches?(request)).to be true
+  end
+
+  it 'returns true when format header is not set' do
+    expect(constraint.matches?(request)).to be true
+  end
+
+  it 'returns false when format header is empty string' do
+    request.headers['Accept'] = ''
+    expect(constraint.matches?(request)).to be false
+  end
+
+  it 'returns false when format header is something else' do
+    request.headers['Accept'] = 'application/json'
+    expect(constraint.matches?(request)).to be false
+  end
+
+end


### PR DESCRIPTION
Codeship uses `wget` to test the URL, which sends `Accept: */*` by
default.  However, it gets a 404 since the constraint only allows for
`text/html`. This updates it to also accept `*/*`.