### PR TITLE
Upgrades: fix rubocop Includes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,12 +5,6 @@ AllCops:
   TargetRubyVersion: 2.5
   DefaultFormatter: fuubar
   DisplayCopNames: true
-  Include:
-    - !ruby/regexp /.*\.rake\z/
-    - Gemfile
-    - Guardfile
-    - Rakefile
-    - config.ru
   Exclude:
     - db/schema.rb
     - !ruby/regexp /node_modules\/.*/
@@ -113,6 +107,7 @@ Style/StringMethods: { Enabled: false } # default disabled
 # intentionally disabled
 # ............................................................................ #
 
+Rails/BulkChangeTable: { Enabled: false }
 Rails/HasManyOrHasOneDependent: { Enabled: false }
 
 RSpec/ExpectInHook: { Enabled: false }

--- a/app/poros/parsers/release_at_parser.rb
+++ b/app/poros/parsers/release_at_parser.rb
@@ -18,11 +18,11 @@ private
 
   def find_timestamp(tags)
     tags.detect do |word|
-      begin
-        Time.zone.parse(word[1..-1])
-      rescue ArgumentError
-        nil
-      end
+
+      Time.zone.parse(word[1..-1])
+    rescue ArgumentError
+      nil
+
     end
   end
 

--- a/spec/lib/html_constraint_spec.rb
+++ b/spec/lib/html_constraint_spec.rb
@@ -1,30 +1,32 @@
-RSpec.describe HtmlConstraint, '#matches?' do
+RSpec.describe HtmlConstraint do
 
-  let(:constraint) { described_class.new }
-  let(:request) { OpenStruct.new(headers: {}) }
+  describe '#matches?' do
+    let(:constraint) { described_class.new }
+    let(:request) { OpenStruct.new(headers: {}) }
 
-  it 'returns true when format has "text/html"' do
-    request.headers['Accept'] = 'footext/htmlbar'
-    expect(constraint.matches?(request)).to be true
-  end
+    it 'returns true when format has "text/html"' do
+      request.headers['Accept'] = 'footext/htmlbar'
+      expect(constraint.matches?(request)).to be true
+    end
 
-  it 'returns true when format has "*/*"' do
-    request.headers['Accept'] = 'foo*/*bar'
-    expect(constraint.matches?(request)).to be true
-  end
+    it 'returns true when format has "*/*"' do
+      request.headers['Accept'] = 'foo*/*bar'
+      expect(constraint.matches?(request)).to be true
+    end
 
-  it 'returns true when format header is not set' do
-    expect(constraint.matches?(request)).to be true
-  end
+    it 'returns true when format header is not set' do
+      expect(constraint.matches?(request)).to be true
+    end
 
-  it 'returns false when format header is empty string' do
-    request.headers['Accept'] = ''
-    expect(constraint.matches?(request)).to be false
-  end
+    it 'returns false when format header is empty string' do
+      request.headers['Accept'] = ''
+      expect(constraint.matches?(request)).to be false
+    end
 
-  it 'returns false when format header is something else' do
-    request.headers['Accept'] = 'application/json'
-    expect(constraint.matches?(request)).to be false
+    it 'returns false when format header is something else' do
+      request.headers['Accept'] = 'application/json'
+      expect(constraint.matches?(request)).to be false
+    end
   end
 
 end


### PR DESCRIPTION
A recent rubocop version changed the behavior of the `Includes` setting
to overwrite rather than merge options, so a bunch of files weren't
being checked for a little while. All of the files in `Includes` are in
the defaults anyway, so this should be fine to remove. Not sure why we
added the setting in the first place.

I disabled the `Rails/BulkChangeTable` setting as it makes it harder to
write reversible migrations and I've never felt any pain with migrations
being too slow.

https://github.com/rubocop-hq/rubocop/issues/6021