### PR TITLE
TypeScript: enable eslint-plugin-typescript

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -26,6 +26,16 @@ settings:
   react:
     version: '16.0'
 
+overrides:
+  - {
+      files: ['**/*.ts', '**/*.tsx'],
+      parser: typescript-eslint-parser,
+      plugins: [typescript],
+      rules: {
+        no-undef: off
+      }
+    }
+
 rules:
   ### to enable/improve
   class-methods-use-this: off
@@ -49,6 +59,7 @@ rules:
   jsx-a11y/no-onchange: off
   jsx-a11y/no-static-element-interactions: off
   jsx-a11y/onclick-has-role: off
+  max-lines-per-function: [error, { max: 110 }]
   max-statements: [error, { max: 14 }]
   multiline-comment-style: off
   no-magic-numbers: off
@@ -58,6 +69,7 @@ rules:
   react/jsx-curly-brace-presence: off
   react/jsx-max-depth: off
   react/jsx-sort-props: off
+  react/sort-comp: off
   react/sort-prop-types: [error, { ignoreCase: true, requiredFirst: true, sortShapeProp: true }]
   react/no-access-state-in-setstate: off
   # semi-urgent to re-enable

--- a/app/javascript/@types/globals.d.ts
+++ b/app/javascript/@types/globals.d.ts
@@ -1,4 +1,4 @@
-declare var debug: any;
+declare const debug: any;
 
 interface Window {
   $: any;

--- a/app/javascript/src/_common/components/sidebar.tsx
+++ b/app/javascript/src/_common/components/sidebar.tsx
@@ -11,7 +11,7 @@ class Sidebar extends React.Component<any, any> {
 
     autobind(this);
 
-    this.state = { visible: false };
+    this.state = {visible: false};
   }
 
   componentWillMount() {

--- a/app/javascript/src/_common/create_merged_reducer.ts
+++ b/app/javascript/src/_common/create_merged_reducer.ts
@@ -19,7 +19,9 @@ function initState(reducerMap) {
 
 function createMergedReducer(reducerMap) {
   return function mergedReducer(previousState, action) {
-    if (action.type.startsWith('@@redux/INIT')) { return initState(reducerMap); }
+    if (action.type.startsWith('@@redux/INIT')) {
+      return initState(reducerMap);
+    }
 
     const reducerKey = getReducerKey(action);
     const reducer = grab(reducerMap, reducerKey);

--- a/app/javascript/src/_helpers/authenticity_token.ts
+++ b/app/javascript/src/_helpers/authenticity_token.ts
@@ -2,7 +2,7 @@ export default function authenticityToken() {
   const tokenTag = document.getElementsByName('csrf-token')[0];
 
   if (!(tokenTag instanceof HTMLMetaElement)) {
-    return;
+    return null;
     // csrf tokens don't work on test for some reason
     // throw new Error('Missing csrf-token meta tag');
   }

--- a/app/javascript/src/_helpers/debug.ts
+++ b/app/javascript/src/_helpers/debug.ts
@@ -1,7 +1,8 @@
 /* eslint-disable no-console */
 
 function isNode() {
-  return typeof process !== 'undefined' && !(<any>process).browser;
+  // eslint-disable-next-line no-extra-parens
+  return typeof process !== 'undefined' && !(process as any).browser;
 }
 
 const terminalEscapes = {

--- a/app/javascript/src/_helpers/flash.ts
+++ b/app/javascript/src/_helpers/flash.ts
@@ -1,4 +1,4 @@
-declare var $: any;
+declare const $: any;
 
 export default function flash(status, message) {
   const $myFlash = $('<div />', {'class': `flash-${status}`, text: message});

--- a/app/javascript/src/scratch/connect_with_scratch.tsx
+++ b/app/javascript/src/scratch/connect_with_scratch.tsx
@@ -40,37 +40,37 @@ function connectWithScratch(
         super(props);
         autobind(this);
 
-        const {createScratch} = this.props;
+        const {createScratch: boundCreateScratch} = this.props;
 
-        createScratch(props.scratchKey);
+        boundCreateScratch(props.scratchKey);
       }
 
       componentWillReceiveProps(nextProps) {
         const {
-          createScratch,
-          deleteScratch,
+          createScratch: boundCreateScratch,
+          deleteScratch: boundDeleteScratch,
           scratch,
           scratchKey,
-          updateScratch,
+          updateScratch: boundUpdateScratch,
         } = this.props;
 
         if (nextProps.scratchKey === scratchKey) { return; }
 
-        createScratch(nextProps.scratchKey);
-        updateScratch(nextProps.scratchKey, scratch);
-        deleteScratch(scratchKey);
+        boundCreateScratch(nextProps.scratchKey);
+        boundUpdateScratch(nextProps.scratchKey, scratch);
+        boundDeleteScratch(scratchKey);
       }
 
       componentWillUnmount() {
-        const {deleteScratch, scratchKey} = this.props;
+        const {deleteScratch: boundDeleteScratch, scratchKey} = this.props;
 
-        deleteScratch(scratchKey);
+        boundDeleteScratch(scratchKey);
       }
 
       updateScratch(payload) {
-        const {scratchKey, updateScratch} = this.props;
+        const {scratchKey, updateScratch: boundUpdateScratch} = this.props;
 
-        updateScratch(scratchKey, payload);
+        boundUpdateScratch(scratchKey, payload);
       }
 
       render() {

--- a/app/javascript/src/task/components/edit_title_form.tsx
+++ b/app/javascript/src/task/components/edit_title_form.tsx
@@ -8,6 +8,7 @@ import {scratchShape, taskShape} from 'src/shapes';
 
 class TaskEditTitleForm extends React.Component<any, any> {
   submitting: boolean;
+
   input: any;
 
   constructor(props) {

--- a/app/javascript/src/task/selectors.ts
+++ b/app/javascript/src/task/selectors.ts
@@ -44,7 +44,10 @@ function grabLeafTasks(orderedTasks, tasksByParentId) {
   return orderedTasks.filter(task => tasksByParentId[task.id].length === 0);
 }
 
-const getTasksById = createSelector((state: State) => state.task.byId, processTasks);
+const getTasksById = createSelector(
+  (state: State) => state.task.byId,
+  processTasks
+);
 
 const getTasksByParentId = createSelector(getTasksById, mapTasksToParentId);
 

--- a/package.json
+++ b/package.json
@@ -58,12 +58,14 @@
     "eslint-plugin-jest": "^21.2.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-react": "^7.3.0",
+    "eslint-plugin-typescript": "^0.12.0",
     "jest": "^23.5.0",
     "jest-enzyme": "^6.0.0",
     "jsdom": "^12.0.0",
     "react-test-renderer": "^16.0.0",
     "stylelint": "^9.5.0",
     "ts-jest": "^23.1.4",
+    "typescript-eslint-parser": "^18.0.0",
     "webpack-dev-server": "^3.1.5"
   },
   "engines": {
@@ -74,7 +76,7 @@
     "lints": "yarn stylelint && yarn eslint && yarn tscheck && yarn rubocop && rake haml_lint",
     "rubocop": "rubocop -f q",
     "stylelint": "./node_modules/stylelint/bin/stylelint.js 'app/assets/stylesheets/**/*.scss'",
-    "eslint": "./node_modules/eslint/bin/eslint.js ./ --ext .js,.jsx --cache",
+    "eslint": "./node_modules/eslint/bin/eslint.js ./ --ext .js,.jsx,.ts,.tsx --cache",
     "jest": "./node_modules/jest/bin/jest.js --config config/jest.json --coverage --maxWorkers 2",
     "pretest": "yarn stylelint && yarn eslint",
     "test": "yarn jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3226,6 +3226,12 @@ eslint-plugin-react@^7.3.0:
     jsx-ast-utils "^2.0.1"
     prop-types "^15.6.2"
 
+eslint-plugin-typescript@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.12.0.tgz#e23d58cb27fe28e89fc641a1f20e8d862cb99aef"
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-scope@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
@@ -5856,6 +5862,10 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "~3.0.0"
 
+lodash.unescape@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
@@ -8464,6 +8474,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -8700,6 +8714,10 @@ selfsigned@^1.9.1:
 "semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.1.tgz#7dfdd8814bdb7cabc7be0fb1d734cfb66c940477"
+
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
 semver@~5.3.0:
   version "5.3.0"
@@ -9568,6 +9586,13 @@ type-is@~1.6.15, type-is@~1.6.16:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript-eslint-parser@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-18.0.0.tgz#3e5055a44980d69e4154350fc5d8b1ab4e2332a8"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 typescript@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Not sure why some of these failures are showing up now, since I think
they've been around for a while. I think maybe `eslint-plugin-react` was
somehow impacting how the rules are enforced.