### PR TITLE
TypeScript: separate out tsconfig-jest.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,6 @@
     "jest": "./node_modules/jest/bin/jest.js --config config/jest.json --coverage --maxWorkers 2",
     "pretest": "yarn stylelint && yarn eslint",
     "test": "yarn jest",
-    "tscheck": "yarn tsc --noEmit"
+    "tscheck": "yarn tsc --noEmit -p tsconfig-test.json"
   }
 }

--- a/tsconfig-test.json
+++ b/tsconfig-test.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "src/*": ["app/javascript/src/*"],
+      "_test_helpers/*": ["spec/javascript/_test_helpers/*"]
+    }
+  },
+  "extends": "./tsconfig",
+  "exclude": [
+    "node_modules",
+    "vendor",
+    "public"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,13 +9,15 @@
     "lib": ["es2017", "dom"],
     "module": "es6",
     "moduleResolution": "node",
-    "paths": {"*": ["app/javascript/*", "spec/javascript/*"]},
+    "paths": {
+      "src/*": ["app/javascript/src/*"]
+    },
     "sourceMap": true,
     "target": "es5",
     "jsx": "react"
   },
   "exclude": [
-    "**/*.spec.ts",
+    "spec",
     "node_modules",
     "vendor",
     "public"


### PR DESCRIPTION
Ran into some complaints trying to deploy, as TypeScript was trying to
compile test files and looking for test libraries, like `enzyme`, which
were in `devDependencies`, so not installed on production. I don't love
this solution, but hopefully this will resolve the issue. Will follow up
if I hear a better approach from [this issue][1].

[1]: https://github.com/rails/webpacker/issues/1685