### PR TITLE
TypeScript: noImplicitAny in notification folder

### DIFF
--- a/app/javascript/@types/globals.d.ts
+++ b/app/javascript/@types/globals.d.ts
@@ -17,11 +17,6 @@ interface Process {
   browser: boolean;
 }
 
-interface Task {
-  id: number,
-  parentTaskId: number,
-}
-
 type BasicAction = {
   type: string;
   payload?: any;

--- a/app/javascript/@types/notification.d.ts
+++ b/app/javascript/@types/notification.d.ts
@@ -1,0 +1,6 @@
+type NotificationKey = 'currentTask';
+
+type AppNotification = {
+  key: NotificationKey;
+  notification: Notification;
+};

--- a/app/javascript/@types/state.d.ts
+++ b/app/javascript/@types/state.d.ts
@@ -1,5 +1,10 @@
+type NotificationState = {
+  trash: 'goober';
+};
+
 type State = {
   common?: any;
+  notification?: NotificationState;
   route?: any;
   tag?: any;
   task?: any;

--- a/app/javascript/@types/task.d.ts
+++ b/app/javascript/@types/task.d.ts
@@ -1,3 +1,9 @@
+type Task = {
+  id: number;
+  parentTaskId: number;
+  title: string;
+};
+
 type AjaxTask = {
   postpone?: boolean;
   done?: boolean;

--- a/app/javascript/src/application.tsx
+++ b/app/javascript/src/application.tsx
@@ -16,7 +16,7 @@ window.addEventListener('popstate', () => {
 });
 
 window.addEventListener('beforeunload', () => {
-  appStore.dispatch(removeNotification({key: 'task'}));
+  appStore.dispatch(removeNotification({key: 'currentTask'}));
 });
 
 // depends on global jQuery, so can't be imported, as that gets hoisted

--- a/app/javascript/src/notification/action_creators.ts
+++ b/app/javascript/src/notification/action_creators.ts
@@ -1,16 +1,28 @@
+import {Action} from 'redux';
+import {ThunkAction} from 'redux-thunk';
+
 const INIT = 'notification/INIT';
 const ADD = 'notification/ADD';
 const REMOVE = 'notification/REMOVE';
 
-function addNotificationPlain(payload) {
+interface AsyncAction extends ThunkAction<void, State, null, Action> { }
+
+type NotificationClickCallback = (event: Event) => any;
+export type Payload = {
+  key: NotificationKey;
+  message: string;
+  onClick: NotificationClickCallback;
+};
+
+function addNotificationPlain(payload: AppNotification) {
   return {type: ADD, payload};
 }
 
-function removeNotificationPlain(payload) {
+function removeNotificationPlain(payload: {key: NotificationKey}) {
   return {type: REMOVE, payload};
 }
 
-function addNotification({key, message, onClick}) {
+function addNotification({key, message, onClick}: Payload): AsyncAction {
   return async function addNotificationThunk(dispatch) {
     const permission = await Notification.requestPermission();
 
@@ -24,7 +36,7 @@ function addNotification({key, message, onClick}) {
   };
 }
 
-function removeNotification(payload) {
+function removeNotification(payload: {key: NotificationKey}): AsyncAction {
   return function removeNotificationThunk(dispatch, getState) {
     const notification = getState().notification[payload.key];
 

--- a/app/javascript/src/notification/components/checkbox.tsx
+++ b/app/javascript/src/notification/components/checkbox.tsx
@@ -1,11 +1,20 @@
 import autobind from 'class-autobind';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {ChangeEvent} from 'react';
 
 import {taskShape} from 'src/shapes';
 
-class NotificationCheckbox extends React.Component<any, any> {
-  constructor(props) {
+type Props = {
+  addNotification: Function;
+  completeTask: Function;
+  notificationsEnabled: boolean;
+  removeNotification: Function;
+  task: Task;
+  updateUser: Function;
+};
+
+class NotificationCheckbox extends React.Component<Props, any> {
+  constructor(props: Props) {
     super(props);
     autobind(this);
   }
@@ -14,7 +23,7 @@ class NotificationCheckbox extends React.Component<any, any> {
     this.notifyOnInterval();
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps: Props) {
     const {notificationsEnabled, task} = this.props;
 
     if (prevProps.task.id !== task.id) { this.notifyTask(); }
@@ -66,7 +75,7 @@ class NotificationCheckbox extends React.Component<any, any> {
     return Boolean(task.id) && notificationsEnabled;
   }
 
-  toggleNotifications(event) {
+  toggleNotifications(event: ChangeEvent<HTMLInputElement>) {
     if (event.target.checked) {
       this.enableNotifications();
     } else {

--- a/app/javascript/src/notification/containers/checkbox.ts
+++ b/app/javascript/src/notification/containers/checkbox.ts
@@ -7,7 +7,7 @@ import {
 } from 'src/notification/action_creators';
 import {updateUser} from 'src/user/action_creators';
 
-function mapStateToProps(state) {
+function mapStateToProps(state: State) {
   return {notificationsEnabled: Boolean(state.user.notificationsEnabled)};
 }
 

--- a/app/javascript/src/notification/reducer.ts
+++ b/app/javascript/src/notification/reducer.ts
@@ -4,16 +4,21 @@ import createBasicReducer from 'src/_common/create_basic_reducer';
 
 import {INIT, ADD, REMOVE} from 'src/notification/action_creators';
 
+type Payload = {
+  key: string;
+  notification: Notification;
+};
+
 export default createBasicReducer({
   [INIT]() {
     return {};
   },
 
-  [ADD](previousState, payload) {
+  [ADD](previousState: NotificationState, payload: Payload) {
     return {...previousState, [payload.key]: payload.notification};
   },
 
-  [REMOVE](previousState, payload) {
+  [REMOVE](previousState: NotificationState, payload: Payload) {
     return update(previousState, {$unset: [payload.key]});
   },
 });

--- a/spec/javascript/notification/action_creators_spec.ts
+++ b/spec/javascript/notification/action_creators_spec.ts
@@ -1,12 +1,15 @@
 import FakeNotification from '_test_helpers/fake_notification';
+import {makeState} from '_test_helpers/factories';
 
 import {
   ADD, REMOVE,
   addNotification, removeNotification,
+  Payload,
 } from 'src/notification/action_creators';
 
 describe('addNotification', () => {
-  const basePayload = {key: 'watKey', message: 'aMessage', onClick: jest.fn()};
+  const basePayload: Payload =
+    {key: 'currentTask', message: 'aMessage', onClick: jest.fn()};
 
   it('returns a removeNotification thunk', () => {
     const payload = {...basePayload, my: 'payload'};
@@ -18,24 +21,23 @@ describe('addNotification', () => {
 
   describe('thunk', () => {
     it('dispatches an ADD action object', async () => {
-      const payload = {...basePayload, key: 'myKey'};
-      const thunk = addNotification(payload);
+      const thunk = addNotification(basePayload);
       const dispatch = jest.fn();
 
-      await thunk(dispatch);
+      await thunk(dispatch, () => makeState({}), null);
 
       const [action] = dispatch.mock.calls[0];
 
       expect(action.type).toBe(ADD);
-      expect(action.payload.key).toBe('myKey');
+      expect(action.payload.key).toBe('currentTask');
     });
 
     it('creates a new notification', async () => {
-      const payload = {...basePayload, key: 'myKey', message: 'my message'};
+      const payload: Payload = {...basePayload, message: 'my message'};
       const thunk = addNotification(payload);
       const dispatch = jest.fn();
 
-      await thunk(dispatch);
+      await thunk(dispatch, () => makeState({}), null);
 
       const [action] = dispatch.mock.calls[0];
       const {notification} = action.payload;
@@ -45,26 +47,24 @@ describe('addNotification', () => {
     });
 
     it('adds a custom onClick handler to the notification', async () => {
-      const payload = {...basePayload, key: 'myKey', onClick: jest.fn()};
-      const thunk = addNotification(payload);
+      const thunk = addNotification(basePayload);
       const dispatch = jest.fn();
 
-      await thunk(dispatch);
+      await thunk(dispatch, () => makeState({}), null);
 
       const [action] = dispatch.mock.calls[0];
       const {notification} = action.payload;
 
-      expect(payload.onClick).not.toHaveBeenCalled();
+      expect(basePayload.onClick).not.toHaveBeenCalled();
       notification.onclick();
-      expect(payload.onClick).toHaveBeenCalled();
+      expect(basePayload.onClick).toHaveBeenCalled();
     });
   });
 });
 
 describe('removeNotification', () => {
   it('returns a removeNotification thunk', () => {
-    const payload = {my: 'payload'};
-    const thunk = removeNotification(payload);
+    const thunk = removeNotification({key: 'currentTask'});
 
     expect(thunk.length).toBe(2);
     expect(thunk.name).toBe('removeNotificationThunk');
@@ -72,33 +72,32 @@ describe('removeNotification', () => {
 
   describe('thunk', () => {
     it('does not try to close a non-existent notification', () => {
-      const payload = {my: 'payload'};
-      const thunk = removeNotification(payload);
+      const thunk = removeNotification({key: 'currentTask'});
       const getState = jest.fn(() => ({notification: {}}));
       const dispatch = jest.fn();
 
-      expect(() => thunk(dispatch, getState)).not.toThrow();
+      expect(() => thunk(dispatch, getState, null)).not.toThrow();
     });
 
     it('closes the associated notification when present', () => {
-      const payload = {key: 'myKey'};
-      const thunk = removeNotification(payload);
+      const thunk = removeNotification({key: 'currentTask'});
       const notification = new FakeNotification('some message');
-      const getState = jest.fn(() => ({notification: {myKey: notification}}));
+      const getState =
+        jest.fn(() => ({notification: {currentTask: notification}}));
       const dispatch = jest.fn();
 
       expect(notification.isOpen).toBe(true);
-      thunk(dispatch, getState);
+      thunk(dispatch, getState, null);
       expect(notification.isOpen).toBe(false);
     });
 
     it('dispatches a REMOVE action', () => {
-      const payload = {my: 'payload'};
+      const payload: {key: NotificationKey} = {key: 'currentTask'};
       const thunk = removeNotification(payload);
       const getState = jest.fn(() => ({notification: {}}));
       const dispatch = jest.fn();
 
-      thunk(dispatch, getState);
+      thunk(dispatch, getState, null);
 
       expect(dispatch).toHaveBeenCalledWith({type: REMOVE, payload});
     });

--- a/spec/javascript/notification/reducer_spec.ts
+++ b/spec/javascript/notification/reducer_spec.ts
@@ -11,10 +11,9 @@ describe(INIT, () => {
 
 describe(ADD, () => {
   it('returns a new object with a payload merged in', () => {
-    const someKey = Math.random();
-    const previousState = {[someKey]: Math.random()};
+    const previousState = {};
     const action = {type: ADD, payload: {key: 'foo', notification: 'bar'}};
-    const expected = {[someKey]: previousState[someKey], foo: 'bar'};
+    const expected = {foo: 'bar'};
 
     expect(notificationReducer(previousState, action)).toEqual(expected);
   });


### PR DESCRIPTION
This fixes a bug in `application.tsx` where it was passing the wrong key
to remove the notification on page unload. I made the type of
`NotificationState` have a garbage key because `{}` allows anything to
be set. Once TypeScript reports some issue with the existing structure,
I'll change it to something more appropriate.