### PR TITLE
Redux: replace initialization condition

### DIFF
--- a/app/javascript/src/_common/create_merged_reducer.ts
+++ b/app/javascript/src/_common/create_merged_reducer.ts
@@ -44,7 +44,7 @@ function createMergedReducer(reducerMap: ReducerMap) {
     previousState: State,
     action: BasicAction | any,
   ) {
-    if (action.type.startsWith('@@redux/INIT')) {
+    if (!previousState) {
       return initState(reducerMap);
     }
 

--- a/spec/javascript/app_store_spec.ts
+++ b/spec/javascript/app_store_spec.ts
@@ -23,7 +23,7 @@ describe('appStore', () => {
     expect(appStore.getState()).toEqual(expectedState);
 
     appStore.subscribe(subSpy);
-    appStore.dispatch({type: '@@redux/INIT'});
+    appStore.dispatch({type: 'task/INIT'});
     expect(subSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The `@@redux/INIT...` action is apparently internal and not meant to be
used, but it looks like we can instead check whether the state is
present at all, as this will be `undefined` on the first call.

https://redux.js.org/recipes/structuringreducers/initializingstate