### PR TITLE
CI: add bundle exec to ruby commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
   },
   "license": "UNLICENSED",
   "scripts": {
-    "lints": "yarn stylelint && yarn eslint && yarn tscheck && yarn rubocop && rake haml_lint",
-    "rubocop": "rubocop -f q",
+    "lints": "yarn stylelint && yarn eslint && yarn tscheck && yarn rubocop && bundle exec rake haml_lint",
+    "rubocop": "bundle exec rubocop -f q",
     "stylelint": "./node_modules/stylelint/bin/stylelint.js 'app/assets/stylesheets/**/*.scss'",
     "eslint": "./node_modules/eslint/bin/eslint.js ./ --ext .js,.jsx,.ts,.tsx --cache",
     "jest": "./node_modules/jest/bin/jest.js --config config/jest.json --coverage --maxWorkers 2 --detectOpenHandles --errorOnDeprecated --notify",


### PR DESCRIPTION
Had a failure on CI complaining about `rake` already being initialized.