### PR TITLE
Deps: reintroduce node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,9 @@
     "typescript-eslint-parser": "^18.0.0",
     "webpack-dev-server": "^3.1.5"
   },
+  "engines": {
+    "node": "8.10.0"
+  },
   "license": "UNLICENSED",
   "scripts": {
     "lints": "yarn stylelint && yarn eslint && yarn tscheck && yarn rubocop && bundle exec rake haml_lint",


### PR DESCRIPTION
NPM packages have a hard dependency on certain node versions, and
they're not strictly increasing. They'll be compatible with `8.10.0` and
`9.10.0` but not `9.1.0`. Let's try a node version that is cross
compatible and see how it goes.