### PR TITLE
Deps: remove erb from elm loader

### DIFF
--- a/config/webpack/loaders/elm.js
+++ b/config/webpack/loaders/elm.js
@@ -24,7 +24,7 @@ if (isProduction) {
 }
 
 module.exports = {
-  test: /\.elm(\.erb)?$/u,
+  test: /\.elm$/u,
   exclude: [/elm-stuff/u, /node_modules/u],
   use: loaders,
 };


### PR DESCRIPTION
We won't be using `erb` in `.elm` files, and [a new ESLint rule fails on
this line][1].

[1]: https://circleci.com/gh/mockdeep/questlog/626