### PR TITLE
Jest: update configuration

### DIFF
--- a/config/jest.json
+++ b/config/jest.json
@@ -1,5 +1,6 @@
 {
   "clearMocks": true,
+  "collectCoverage": true,
   "collectCoverageFrom": ["app/javascript/**/*.(js|ts|tsx)", "!**/*.d.ts"],
   "coverageReporters": ["json", "lcov"],
   "coverageThreshold": {
@@ -10,14 +11,17 @@
       "lines": 82.79
     }
   },
+  "errorOnDeprecated": true,
   "moduleFileExtensions": ["js", "ts", "tsx"],
   "modulePaths": [
     "<rootDir>/app/javascript",
     "<rootDir>/vendor/assets/javascripts/",
     "<rootDir>/spec/javascript/"
   ],
+  "notify": true,
+  "notifyMode": "always",
   "rootDir": "../",
-  "setupTestFrameworkScriptFile": "<rootDir>/spec/javascript/test_helper.ts",
+  "setupFilesAfterEnv": ["<rootDir>/spec/javascript/test_helper.ts"],
   "testRegex": "/spec/javascript/.*_spec.(js|ts|tsx)$",
   "testURL": "http://test.host",
   "transform": {

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "rubocop": "bundle exec rubocop -f q",
     "stylelint": "./node_modules/stylelint/bin/stylelint.js 'app/assets/stylesheets/**/*.scss'",
     "eslint": "./node_modules/eslint/bin/eslint.js ./ --ext .js,.jsx,.ts,.tsx --cache",
-    "jest": "./node_modules/jest/bin/jest.js --config config/jest.json --coverage --maxWorkers 2 --detectOpenHandles --errorOnDeprecated --notify",
+    "jest": "./node_modules/jest/bin/jest.js --config config/jest.json  --maxWorkers 2",
     "pretest": "yarn stylelint && yarn tscheck && yarn eslint",
     "test": "yarn jest",
     "tscheck": "yarn tsc --noEmit -p tsconfig-test.json"


### PR DESCRIPTION
* Swap out deprecated `setupTestFrameworkScriptFile` config for
  `setupFilesAfterEnv`
* Move CLI options to config file.