### PR TITLE
CI: make feature tests depend on js tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,6 @@ workflows:
       - unit_tests:
           requires: [lints]
       - feature_tests_chrome_headless:
-          requires: [unit_tests]
+          requires: [unit_tests, javascript_tests]
       - feature_tests_chrome:
-          requires: [unit_tests]
+          requires: [unit_tests, javascript_tests]


### PR DESCRIPTION
It doesn't make sense to run the features if the JS tests fail. That
should speed things up on the build side as well.