### PR TITLE
TypeScript: make state keys required

### DIFF
--- a/app/javascript/@types/state.d.ts
+++ b/app/javascript/@types/state.d.ts
@@ -30,13 +30,13 @@ type UserState = {
 };
 
 type State = {
-  common?: CommonState;
-  notification?: NotificationState;
-  route?: RouteState;
-  scratch?: ScratchState;
-  tag?: TagState;
-  task?: TaskState;
-  user?: UserState;
+  common: CommonState;
+  notification: NotificationState;
+  route: RouteState;
+  scratch: ScratchState;
+  tag: TagState;
+  task: TaskState;
+  user: UserState;
 };
 
 type StateKey = keyof State;

--- a/app/javascript/src/notification/action_creators.ts
+++ b/app/javascript/src/notification/action_creators.ts
@@ -4,6 +4,7 @@ import {ThunkAction} from 'redux-thunk';
 const INIT = 'notification/INIT';
 const ADD = 'notification/ADD';
 const REMOVE = 'notification/REMOVE';
+const SET = 'notification/SET';
 
 interface AsyncAction extends ThunkAction<void, State, null, Action> { }
 
@@ -46,5 +47,5 @@ function removeNotification(payload: {key: NotificationKey}): AsyncAction {
   };
 }
 
-export {INIT, ADD, REMOVE};
+export {INIT, ADD, REMOVE, SET};
 export {addNotification, removeNotification};

--- a/app/javascript/src/notification/reducer.ts
+++ b/app/javascript/src/notification/reducer.ts
@@ -2,7 +2,7 @@ import update from 'immutability-helper';
 
 import createBasicReducer from 'src/_common/create_basic_reducer';
 
-import {INIT, ADD, REMOVE} from 'src/notification/action_creators';
+import {INIT, ADD, REMOVE, SET} from 'src/notification/action_creators';
 
 type Payload = {
   key: NotificationKey;
@@ -20,5 +20,9 @@ export default createBasicReducer({
 
   [REMOVE](previousState: NotificationState, payload: Payload) {
     return update(previousState, {$unset: [payload.key]});
+  },
+
+  [SET](previousState: NotificationState, payload: NotificationState) {
+    return payload;
   },
 });

--- a/app/javascript/src/scratch/action_creators.ts
+++ b/app/javascript/src/scratch/action_creators.ts
@@ -1,6 +1,7 @@
 const INIT = 'scratch/INIT';
 const CREATE = 'scratch/CREATE';
 const DELETE = 'scratch/DELETE';
+const SET = 'scratch/SET';
 const UPDATE = 'scratch/UPDATE';
 
 import {Action} from 'redux';
@@ -59,6 +60,6 @@ function updateScratch(
   };
 }
 
-export {INIT, CREATE, DELETE, UPDATE};
+export {INIT, CREATE, DELETE, SET, UPDATE};
 export {createScratchPlain, deleteScratchPlain, updateScratchPlain};
 export {createScratch, deleteScratch, updateScratch};

--- a/app/javascript/src/scratch/reducer.ts
+++ b/app/javascript/src/scratch/reducer.ts
@@ -2,7 +2,7 @@ import update from 'immutability-helper';
 
 import createBasicReducer from 'src/_common/create_basic_reducer';
 
-import {INIT, CREATE, DELETE, UPDATE} from 'src/scratch/action_creators';
+import {INIT, CREATE, DELETE, SET, UPDATE} from 'src/scratch/action_creators';
 
 export default createBasicReducer({
   [INIT]() {
@@ -15,6 +15,10 @@ export default createBasicReducer({
 
   [DELETE](previousState: ScratchState, key: string) {
     return update(previousState, {$unset: [key]});
+  },
+
+  [SET](previousState: ScratchState, payload: ScratchState) {
+    return payload;
   },
 
   [UPDATE](previousState: ScratchState, {key, ...scratch}: {key: string}) {

--- a/app/javascript/src/user/action_creators.ts
+++ b/app/javascript/src/user/action_creators.ts
@@ -1,9 +1,10 @@
 const INIT = 'user/INIT';
+const SET = 'user/SET';
 const UPDATE = 'user/UPDATE';
 
 function updateUser(payload: User) {
   return {type: UPDATE, payload};
 }
 
-export {INIT, UPDATE};
+export {INIT, SET, UPDATE};
 export {updateUser};

--- a/app/javascript/src/user/reducer.ts
+++ b/app/javascript/src/user/reducer.ts
@@ -1,10 +1,14 @@
 import createBasicReducer from 'src/_common/create_basic_reducer';
 
-import {INIT, UPDATE} from 'src/user/action_creators';
+import {INIT, SET, UPDATE} from 'src/user/action_creators';
 
 export default createBasicReducer({
   [INIT]() {
     return {};
+  },
+
+  [SET](previousState: State, payload: User) {
+    return payload;
   },
 
   [UPDATE](previousState: State, payload: User) {

--- a/spec/javascript/_test_helpers/factories.ts
+++ b/spec/javascript/_test_helpers/factories.ts
@@ -14,7 +14,7 @@ const timeframeNames: TimeframeName[] = [
   'decade',
 ];
 
-function makeState(attrs: {[key in keyof State]: any}): State {
+function makeState(attrs: {[key in keyof State]?: any}): State {
   return Object.keys(attrs).reduce((state: State, key: StateKey) => {
     const action = {type: `${key}/SET`, payload: attrs[key]};
 

--- a/spec/javascript/app_reducer_spec.ts
+++ b/spec/javascript/app_reducer_spec.ts
@@ -1,5 +1,7 @@
 import reducer from 'src/app_reducer';
 
+import {makeState} from '_test_helpers/factories';
+
 describe('appReducer', () => {
   describe('init', () => {
     it('returns a blank nested tree of state', () => {
@@ -29,7 +31,7 @@ describe('appReducer', () => {
     it('delegates to the user reducer', () => {
       const action = {type: 'user/UPDATE', payload: {goober: 'globber'}};
       const notificationState = {notificationsEnabled: true};
-      const result = reducer({user: notificationState}, action);
+      const result = reducer(makeState({user: notificationState}), action);
 
       expect(result).toEqual({user: {...notificationState, goober: 'globber'}});
     });
@@ -41,7 +43,7 @@ describe('appReducer', () => {
       const message = /invalid reducer key "booger"/u;
 
       expect(() => {
-        reducer({user: {notificationsEnabled: false}}, action);
+        reducer(makeState({user: {notificationsEnabled: false}}), action);
       }).toThrow(message);
     });
   });

--- a/spec/javascript/notification/action_creators_spec.ts
+++ b/spec/javascript/notification/action_creators_spec.ts
@@ -73,7 +73,9 @@ describe('removeNotification', () => {
   describe('thunk', () => {
     it('does not try to close a non-existent notification', () => {
       const thunk = removeNotification({key: 'currentTask'});
-      const getState = jest.fn(() => ({notification: {currentTask: null}}));
+      function getState() {
+        return makeState({notification: {currentTask: null}});
+      }
       const dispatch = jest.fn();
 
       expect(() => thunk(dispatch, getState, null)).not.toThrow();
@@ -82,8 +84,9 @@ describe('removeNotification', () => {
     it('closes the associated notification when present', () => {
       const thunk = removeNotification({key: 'currentTask'});
       const notification = new FakeNotification('some message');
-      const getState =
-        jest.fn(() => ({notification: {currentTask: notification}}));
+      function getState() {
+        return makeState({notification: {currentTask: notification}});
+      }
       const dispatch = jest.fn();
 
       expect(notification.isOpen).toBe(true);
@@ -94,7 +97,9 @@ describe('removeNotification', () => {
     it('dispatches a REMOVE action', () => {
       const payload: {key: NotificationKey} = {key: 'currentTask'};
       const thunk = removeNotification(payload);
-      const getState = jest.fn(() => ({notification: {currentTask: null}}));
+      function getState() {
+        return makeState({notification: {currentTask: null}});
+      }
       const dispatch = jest.fn();
 
       thunk(dispatch, getState, null);

--- a/spec/javascript/scratch/action_creators_spec.ts
+++ b/spec/javascript/scratch/action_creators_spec.ts
@@ -3,13 +3,15 @@ import {
   createScratch, deleteScratch, updateScratch,
 } from 'src/scratch/action_creators';
 
+import {makeState} from '_test_helpers/factories';
+
 describe('createScratch', () => {
   describe('thunk', () => {
     it('dispatches a CREATE action object', () => {
       const scratchKey = 'some key thing';
       const expectedAction = {type: CREATE, payload: scratchKey};
       const dispatch = jest.fn();
-      const getState = jest.fn(() => ({scratch: {}}));
+      function getState() { return makeState({scratch: {}}); }
       const thunk = createScratch(scratchKey);
 
       thunk(dispatch, getState, null);
@@ -21,7 +23,7 @@ describe('createScratch', () => {
       const scratchKey = 'some key thing';
       const scratch = {[scratchKey]: {}};
       const dispatch = jest.fn();
-      const getState = jest.fn(() => ({scratch}));
+      function getState() { return makeState({scratch}); }
       const thunk = createScratch(scratchKey);
 
       expect(() => {
@@ -38,7 +40,7 @@ describe('deleteScratch', () => {
       const scratch = {[scratchKey]: {}};
       const expectedAction = {type: DELETE, payload: scratchKey};
       const dispatch = jest.fn();
-      const getState = jest.fn(() => ({scratch}));
+      function getState() { return makeState({scratch}); }
       const thunk = deleteScratch(scratchKey);
 
       thunk(dispatch, getState, null);
@@ -49,7 +51,7 @@ describe('deleteScratch', () => {
     it('throws an error when scratchKey does not exists', () => {
       const scratchKey = 'some key thing';
       const dispatch = jest.fn();
-      const getState = jest.fn(() => ({scratch: {}}));
+      function getState() { return makeState({scratch: {}}); }
       const thunk = deleteScratch(scratchKey);
 
       expect(() => {
@@ -67,7 +69,7 @@ describe('updateScratch', () => {
       const payload = {key: scratchKey, taskTitle: 'butz'};
       const expectedAction = {type: UPDATE, payload};
       const dispatch = jest.fn();
-      const getState = jest.fn(() => ({scratch}));
+      function getState() { return makeState({scratch}); }
       const thunk = updateScratch(scratchKey, {taskTitle: 'butz'});
 
       thunk(dispatch, getState, null);
@@ -78,7 +80,7 @@ describe('updateScratch', () => {
     it('throws an error when scratchKey does not exists', () => {
       const scratchKey = 'some key thing';
       const dispatch = jest.fn();
-      const getState = jest.fn(() => ({scratch: {}}));
+      function getState() { return makeState({scratch: {}}); }
       const thunk = updateScratch(scratchKey, {});
 
       expect(() => {


### PR DESCRIPTION
This updates the tests to use properly shaped state. It also adds `SET`
keys to a handful of state reducers, which I have mixed feelings about,
since it's only for the convenience of the `makeState` factory. Maybe
there's a better way to accomplish this, but this seemed like the
cleanest.