### PR TITLE
CI: enable ram postgres build on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
           PGHOST: 127.0.0.1
           PGUSER: postgres
           RAILS_ENV: test
-      - image: circleci/postgres:10.1-alpine
+      - image: circleci/postgres:10.1-alpine-ram
         environment:
           POSTGRES_USER: postgres
           POSTGRES_DB: app_test


### PR DESCRIPTION
There is some hope that this will make builds faster as Postgres stores
in RAM instead of on disk.

https://circleci.com/docs/2.0/databases/#optimizing-postgres-images