### PR TITLE
switch to @babel/core

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "questlog",
   "repository": "https://github.com/mockdeep/questlog",
   "dependencies": {
+    "@babel/core": "^7.5.5",
     "@rails/webpacker": "^4.0.7",
     "@types/classnames": "^2.2.9",
     "@types/hoist-non-react-statics": "^3.3.0",
@@ -13,7 +14,6 @@
     "@types/react-modal": "^3.8.2",
     "@types/react-redux": "^7.1.1",
     "@types/react-textarea-autosize": "^4.3.4",
-    "babel-core": "^6.26.0",
     "babel-loader": "8.0.6",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@>=7.2.2", "@babel/core@^7.1.0", "@babel/core@^7.4.5":
+"@babel/core@>=7.2.2", "@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
   integrity sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==


### PR DESCRIPTION
Not sure when this changed, but it looks like now they recommend using
`@babel/core`.