### PR TITLE
add webpack as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "reselect": "^4.0.0",
     "ts-loader": "^6.0.4",
     "typescript": "^3.5.3",
+    "webpack": "^4.39.1",
     "whatwg-fetch": "^3.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11173,7 +11173,7 @@ webpack-sources@^1.0.0, webpack-sources@^1.0.1, webpack-sources@^1.1.0, webpack-
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.32.2:
+webpack@^4.32.2, webpack@^4.39.1:
   version "4.39.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.39.1.tgz#60ed9fb2b72cd60f26ea526c404d2a4cc97a1bd8"
   integrity sha512-/LAb2TJ2z+eVwisldp3dqTEoNhzp/TLCZlmZm3GGGAlnfIWDgOEE758j/9atklNLfRyhKbZTCOIoPqLJXeBLbQ==


### PR DESCRIPTION
Yarn was complaining about an unmet peer dependency. Because Webpack is
such a major part of our application, probably best to have it as a
direct dependency rather than a transitive one.