### PR TITLE
NoReact: Replace Link component in Sidebar

### DIFF
--- a/app/javascript/src/_common/components/sidebar.tsx
+++ b/app/javascript/src/_common/components/sidebar.tsx
@@ -1,7 +1,6 @@
 import autobind from 'class-autobind';
 import React from 'react';
 
-import Link from 'src/route/containers/link';
 import {assert} from 'src/_helpers/assert';
 
 type LocalState = {
@@ -26,11 +25,10 @@ class Sidebar extends React.Component<any, any> {
   }
 
   updateScreenSize() {
-    const mobile = this.mediaQueryList.matches;
-    const visible = !mobile;
+    const visible = !this.mediaQueryList.matches;
     this.toggleSidebarClass(visible);
 
-    this.setState({mobile, visible});
+    this.setState({visible});
   }
 
   toggleSidebarClass(visible: boolean) {
@@ -61,12 +59,6 @@ class Sidebar extends React.Component<any, any> {
     );
   }
 
-  hideIfMobile() {
-    const {mobile} = this.state;
-
-    if (mobile) { this.setState({visible: false}); }
-  }
-
   render() {
     const {visible} = this.state;
 
@@ -78,18 +70,31 @@ class Sidebar extends React.Component<any, any> {
       );
     }
 
-    const linkProps = {
-      baseClass: 'sidebar__link',
-      onNavigate: this.hideIfMobile,
-    };
+    const links = [
+      {path: '/', text: 'FOCUS'},
+      {path: '/tasks', text: 'ALL TASKS'},
+      {path: '/timeframes', text: 'TIMEFRAMES'},
+    ];
 
     return (
       <div className='sidebar sidebar--visible'>
         <h2 className='sidebar__header'>{'Menu'}{this.sidebarToggle()}</h2>
         <hr className='sidebar__divider' />
-        <Link to='root' {...linkProps}><h2>{'FOCUS'}</h2></Link>
-        <Link to='tasks' {...linkProps}><h2>{'ALL TASKS'}</h2></Link>
-        <Link to='timeframes' {...linkProps}><h2>{'TIMEFRAMES'}</h2></Link>
+        {
+          links.map(link => {
+            let className = 'sidebar__link';
+
+            if (window.location.pathname === link.path) {
+              className = `${className} ${className}--active`;
+            }
+
+            return (
+              <a href={link.path} className={className} key={link.path}>
+                <h2>{link.text}</h2>
+              </a>
+            );
+          })
+        }
       </div>
     );
   }

--- a/config/jest.json
+++ b/config/jest.json
@@ -5,7 +5,7 @@
   "coverageReporters": ["json", "lcov"],
   "coverageThreshold": {
     "global": {
-      "statements": 87.13,
+      "statements": 87.11,
       "branches": 76.4,
       "functions": 79.78,
       "lines": 88.79

--- a/spec/features/timeframes_spec.rb
+++ b/spec/features/timeframes_spec.rb
@@ -68,13 +68,13 @@ RSpec.describe 'timeframes', js: true do
     expect(page).to have_no_task
 
     Timecop.travel(Time.zone.parse('2014/04/16'))
-    milliseconds = Time.zone.now.to_i * 1000
-    page.execute_script("window.balanceTime = #{milliseconds}")
 
     create(:stat, user: user, timestamp: 3.days.ago, value: 3600)
     create(:stat, user: user, timestamp: 4.days.ago, value: 4000)
 
     sidebar.click('TIMEFRAMES')
+    milliseconds = Time.zone.now.to_i * 1000
+    page.execute_script("window.balanceTime = #{milliseconds}")
 
     expect(page).to have_content('Median Productivity')
 

--- a/spec/javascript/_common/components/sidebar_spec.tsx
+++ b/spec/javascript/_common/components/sidebar_spec.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import {setMatches} from '_test_helpers/match_media';
-import Link from 'src/route/containers/link';
 import Sidebar from 'src/_common/components/sidebar';
-import {assert} from 'src/_helpers/assert';
 
 beforeEach(() => {
   document.body.innerHTML = '<div class="content"></div>';
@@ -13,22 +11,22 @@ beforeEach(() => {
 it('updates the mobile status when screen size changes', () => {
   const component = shallow(<Sidebar />);
 
-  expect(component.find(Link)).toHaveLength(3);
+  expect(component.find('a')).toHaveLength(3);
 
   setMatches(true);
   component.update();
 
-  expect(component.find(Link)).toHaveLength(0);
+  expect(component.find('a')).toHaveLength(0);
 });
 
 describe('when browser is desktop', () => {
-  it('displays the sidebar by default when not on a mobile browser', () => {
+  it('displays the sidebar by default', () => {
     const component = shallow(<Sidebar />);
 
-    const links = component.find(Link);
+    const links = component.find('a');
 
     expect(links).toHaveLength(3);
-    expect(links.at(0)).toHaveProp('to', 'root');
+    expect(links.at(0)).toHaveProp('href', '/');
     expect(links.at(0)).toContainReact(<h2>{'FOCUS'}</h2>);
   });
 
@@ -39,16 +37,7 @@ describe('when browser is desktop', () => {
     component.find('.sidebar__toggle').simulate('click', {preventDefault});
 
     expect(preventDefault).toHaveBeenCalled();
-    expect(component.find(Link)).not.toExist();
-  });
-
-  it('does not hide the sidebar after a link is clicked', () => {
-    const component = shallow(<Sidebar />);
-
-    assert(component.find(Link).at(0).prop('onNavigate'))();
-    component.update();
-
-    expect(component.find(Link)).toHaveLength(3);
+    expect(component.find('a')).not.toExist();
   });
 });
 
@@ -60,7 +49,7 @@ describe('when browser is mobile', () => {
   it('hides the sidebar by default', () => {
     const component = shallow(<Sidebar />);
 
-    expect(component.find(Link)).not.toExist();
+    expect(component.find('a')).not.toExist();
   });
 
   it('displays the sidebar when toggle is clicked', () => {
@@ -69,22 +58,10 @@ describe('when browser is mobile', () => {
 
     component.find('.sidebar__toggle').simulate('click', {preventDefault});
 
-    const links = component.find(Link);
+    const links = component.find('a');
 
     expect(preventDefault).toHaveBeenCalled();
     expect(links).toHaveLength(3);
-    expect(links.at(0)).toHaveProp('to', 'root');
-  });
-
-  it('hides the sidebar after a link is clicked', () => {
-    const component = shallow(<Sidebar />);
-    const preventDefault = jest.fn();
-
-    component.find('.sidebar__toggle').simulate('click', {preventDefault});
-
-    assert(component.find(Link).at(0).prop('onNavigate'))();
-    component.update();
-
-    expect(component.find(Link)).not.toExist();
+    expect(links.at(0)).toHaveProp('href', '/');
   });
 });

--- a/spec/support/wrappers/sidebar.rb
+++ b/spec/support/wrappers/sidebar.rb
@@ -27,6 +27,7 @@ module Questlog
       def click(link_text)
         open
         element.find('a', text: link_text).click
+        expect(page).to have_selector('.sidebar__link--active', text: link_text)
         close
       end
     end


### PR DESCRIPTION
Instead use `a` tags with plain `href`, which will cause a page refresh.