### PR TITLE
get ruby code coverage up to 100%

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,14 +65,4 @@ private
     redirect_to(session.delete(:return_path) || fallback_path, options)
   end
 
-  def store_return_path
-    session[:return_path] = request.fullpath
-  end
-
-  def login_first
-    store_return_path
-    flash[:notice] = 'Please login first'
-    redirect_to '/sessions/new'
-  end
-
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
 
   config.action_controller.action_on_unpermitted_parameters = :raise
 
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that

--- a/spec/controllers/charges_controller/new_spec.rb
+++ b/spec/controllers/charges_controller/new_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe ChargesController, '#new' do
+  it 'renders a script tag with the stripe checkout source' do
+    stripe_publishable_key = ENV['STRIPE_PUBLISHABLE_KEY']
+    expect(stripe_publishable_key).not_to be_blank
+
+    get(:new)
+
+    body = Capybara.string(response.body)
+    script_tag = body.find('.stripe-button', visible: false)
+
+    expect(script_tag['data-key']).to eq(stripe_publishable_key)
+  end
+end

--- a/spec/controllers/free_accounts_controller/new_spec.rb
+++ b/spec/controllers/free_accounts_controller/new_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe FreeAccountsController, '#new' do
+  it 'renders a form to sign up for a new account' do
+    get(:new)
+
+    expect(response.body).to match(/Sign Up/)
+  end
+end

--- a/spec/controllers/pages_controller/index_spec.rb
+++ b/spec/controllers/pages_controller/index_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe PagesController, '#index' do
+  it 'renders blank html' do
+    get(:index)
+
+    body = Capybara.string(response.body)
+    app_base = body.find('#app-base')
+
+    expect(app_base.find(:xpath, './/..').text).to be_blank
+  end
+end

--- a/spec/lib/json_constraint_spec.rb
+++ b/spec/lib/json_constraint_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe JsonConstraint do
+  describe '#matches?' do
+    it 'returns true when accept headers include "application/json"' do
+      request = OpenStruct.new(headers: { 'Accept' => 'application/json' })
+
+      expect(described_class.new.matches?(request)).to be(true)
+    end
+
+    it 'returns false when accept headers do not include "application/json"' do
+      request = OpenStruct.new(headers: { 'Accept' => '' })
+
+      expect(described_class.new.matches?(request)).to be(false)
+    end
+  end
+end

--- a/spec/lib/serializable/config_spec.rb
+++ b/spec/lib/serializable/config_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe Serializable::Config do
+  after do
+    described_class.remove_instance_variable(:@key_format)
+  end
+
+  describe '#key_format=' do
+    it 'sets a new key format' do
+      described_class.key_format = :butt_format
+
+      expect(described_class.key_format).to eq(:butt_format)
+    end
+  end
+
+  describe '#key_format' do
+    it 'returns the set key format' do
+      described_class.key_format = :butt_format
+
+      expect(described_class.key_format).to eq(:butt_format)
+    end
+
+    it 'returns :camelcase by default' do
+      expect(described_class.key_format).to eq(:camelcase)
+    end
+  end
+end

--- a/spec/lib/serializable/locator_spec.rb
+++ b/spec/lib/serializable/locator_spec.rb
@@ -1,0 +1,8 @@
+RSpec.describe Serializable::Locator do
+  describe '.call' do
+    it 'raises an error when serializer cannot be found' do
+      expect { described_class.(Object.new) }
+        .to raise_error('no serializer found for Object')
+    end
+  end
+end

--- a/spec/lib/serializable/root_serializer_spec.rb
+++ b/spec/lib/serializable/root_serializer_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Serializable::RootSerializer do
+  describe '.call' do
+    it 'raises an error when invalid options are passed' do
+      expected_error = 'invalid serializer options: [:boogers], ' \
+          'allowed options are [:meta, :included]'
+
+      expect { described_class.(Object.new, boogers: 'bar') }
+        .to raise_error(expected_error)
+    end
+
+    it 'raises an error when :meta key is not a hash' do
+      expect { described_class.(Object.new, meta: 'bar') }
+        .to raise_error('"meta" key must be a hash')
+    end
+
+    it 'raises an error when :included key is not a collection' do
+      expect { described_class.(Object.new, included: 'bar') }
+        .to raise_error('"included" key must be a collection')
+    end
+  end
+end

--- a/spec/lib/serializable_spec.rb
+++ b/spec/lib/serializable_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe Serializable do
+  after { Serializable::Config.remove_instance_variable(:@key_format) }
+
+  def stub_classes
+    stub_const('TestObjectSerializer', Class.new do
+      include Serializable
+
+      serialize :test_attribute
+    end)
+
+    stub_const('TestObject', Class.new do
+      attr_accessor :test_attribute
+    end)
+  end
+
+  it 'serializes attributes in camelcase when key format is :camelcase' do
+    stub_classes
+    Serializable::Config.key_format = :camelcase
+    test_object = TestObject.new
+    test_object.test_attribute = 'boo'
+
+    expect(TestObjectSerializer.(test_object)).to eq(testAttribute: 'boo')
+  end
+
+  it 'serializes attributes in snakecase when key format is :snakecase' do
+    stub_classes
+    Serializable::Config.key_format = :snakecase
+    test_object = TestObject.new
+    test_object.test_attribute = 'boo'
+
+    expect(TestObjectSerializer.(test_object)).to eq(test_attribute: 'boo')
+  end
+
+  it 'raises an error when an invalid key format is set' do
+    stub_classes
+    Serializable::Config.key_format = :boogercase
+
+    expect { TestObjectSerializer.(TestObject.new) }
+      .to raise_error(KeyError, 'key not found: :boogercase')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'simplecov'
 if ENV['COVERAGE'] != 'false'
   SimpleCov.start 'rails'
-  SimpleCov.minimum_coverage 97
+  SimpleCov.minimum_coverage 100
 end
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
- I needed to change `cache_classes` to `false` in dev mode for running
  tests since classes in the `lib/` folder don't get reloaded
  automatically. As such when I made modifications to exercise the
  tests, they wouldn't be reloaded. The Rails default is for this to be
  `false` anyway in test mode.
- The `login_first` and `store_return_path` methods in
  `ApplicationController` were unused, so I removed them.