### PR TITLE
TypeScript: make task meta attributes required

### DIFF
--- a/app/javascript/@types/task.d.ts
+++ b/app/javascript/@types/task.d.ts
@@ -56,8 +56,8 @@ type BulkTaskStoreType = {
 };
 
 type TaskMeta = {
-  ajaxState?: 'taskSaving' | 'fetching' | 'ready';
-  newTask?: Partial<Task>;
+  ajaxState: 'taskSaving' | 'fetching' | 'ready';
+  newTask: Partial<Task>;
 };
 
 type AjaxTask = {

--- a/app/javascript/src/task/action_creators.ts
+++ b/app/javascript/src/task/action_creators.ts
@@ -29,7 +29,7 @@ function setTasks(payload: Task[]) {
   return {type: SET, payload};
 }
 
-function updateTaskMeta(payload: TaskMeta) {
+function updateTaskMeta(payload: Partial<TaskMeta>) {
   return {type: UPDATE_META, payload};
 }
 

--- a/spec/javascript/task/action_creators_spec.tsx
+++ b/spec/javascript/task/action_creators_spec.tsx
@@ -234,7 +234,7 @@ describe('updateTask', () => {
 
 describe('updateTaskMeta', () => {
   it('returns an UPDATE_META action', () => {
-    const payload: TaskMeta = {ajaxState: 'taskSaving'};
+    const payload: Partial<TaskMeta> = {ajaxState: 'taskSaving'};
 
     expect(updateTaskMeta(payload)).toEqual({type: UPDATE_META, payload});
   });


### PR DESCRIPTION
These should always be set to something, since they're given a default
on initialize.