### PR TITLE
TypeScript: use assert helper in a few places

### DIFF
--- a/app/javascript/@types/task.d.ts
+++ b/app/javascript/@types/task.d.ts
@@ -1,15 +1,13 @@
 type TaskLoadingState = 'marking_done' | 'postponing' | 'ready' | 'updating';
 
-type Task = {
+type BaseTask = {
   id: number;
   done: boolean;
   estimateMinutes: number;
   estimateSeconds: number | null;
   parentTaskId: number | null;
-  pending: boolean;
   position: number;
   priority: number | null;
-  releaseAt: string | null;
   repeatSeconds: number | null;
   skipCount: number;
   status: 'active' | 'done' | 'pending';
@@ -19,6 +17,18 @@ type Task = {
   title: string;
   loadingState: TaskLoadingState;
 };
+
+type PendingTask = BaseTask & {
+  pending: true;
+  releaseAt: string;
+}
+
+type CurrentTask = BaseTask & {
+  pending: false;
+  releaseAt: null;
+}
+
+type Task = PendingTask | CurrentTask;
 
 type BulkTask = {
   positions?: number[];

--- a/app/javascript/src/_common/components/sidebar.tsx
+++ b/app/javascript/src/_common/components/sidebar.tsx
@@ -2,6 +2,7 @@ import autobind from 'class-autobind';
 import React from 'react';
 
 import Link from 'src/route/containers/link';
+import {assert} from 'src/_helpers/assert';
 
 type LocalState = {
   visible: boolean;
@@ -33,7 +34,7 @@ class Sidebar extends React.Component<any, any> {
   }
 
   toggleSidebarClass(visible: boolean) {
-    const contentDiv = document.querySelector('.content');
+    const contentDiv = assert(document.querySelector('.content'));
     contentDiv.classList.toggle('sidebar-open', visible);
   }
 

--- a/app/javascript/src/_helpers/assert.ts
+++ b/app/javascript/src/_helpers/assert.ts
@@ -1,0 +1,9 @@
+function assert<T>(value: T | null | undefined): T {
+  if (value === null || typeof value === 'undefined') {
+    throw new Error('value is null or undefined');
+  }
+
+  return value;
+}
+
+export {assert};

--- a/app/javascript/src/task/components/list_view.tsx
+++ b/app/javascript/src/task/components/list_view.tsx
@@ -11,10 +11,11 @@ import NewTaskForm from 'src/task/containers/new_task_form';
 import TableHeaders from 'src/task/components/table_headers';
 import TaskListFilters from 'src/task/components/list_filters';
 import DraggableTaskRow from 'src/task/components/draggable_task_row';
+import {assert} from 'src/_helpers/assert';
 import {taskShape} from 'src/shapes';
 
-function findTask(tasks: Task[], taskId: number) {
-  return tasks.find(task => task.id === taskId);
+function findTask(tasks: Task[], taskId: number): Task {
+  return assert(tasks.find(task => task.id === taskId));
 }
 
 function afterTaskHasHigherPriority(task: Task, afterTask: Task) {

--- a/app/javascript/src/task/reducer.ts
+++ b/app/javascript/src/task/reducer.ts
@@ -15,7 +15,7 @@ function estimateMinutes(task: Task) {
   return Math.floor((task.estimateSeconds || 1800) / 60);
 }
 
-function processTask(task: Task) {
+function processTask(task: Task): Task {
   const processedTask = {
     loadingState: 'ready',
     ...task,

--- a/app/javascript/src/timeframe/utils.ts
+++ b/app/javascript/src/timeframe/utils.ts
@@ -5,6 +5,7 @@ import {sumBy} from 'lodash';
 
 import grab from 'src/_helpers/grab';
 import TimeBalancer from 'src/_helpers/time_balancer';
+import {assert} from 'src/_helpers/assert';
 
 const timeframeEnds: {[timeframeName in TimeframeName]: Moment} = {
   inbox: null,
@@ -51,8 +52,8 @@ function calculateTotalMinutes(timeframe: Timeframe) {
 }
 
 function timeframeNameForPendingTask(task: Task) {
-  const releaseAt = moment(task.releaseAt);
-  let index = timeframeList.indexOf(task.timeframe) - 1;
+  const releaseAt = moment(assert(task.releaseAt));
+  let index = timeframeList.indexOf(assert(task.timeframe)) - 1;
   let timeframeName;
   let timeframeEnd;
 

--- a/spec/javascript/_common/components/sidebar_spec.tsx
+++ b/spec/javascript/_common/components/sidebar_spec.tsx
@@ -4,6 +4,7 @@ import {shallow} from 'enzyme';
 import {setMatches} from '_test_helpers/match_media';
 import Link from 'src/route/containers/link';
 import Sidebar from 'src/_common/components/sidebar';
+import {assert} from 'src/_helpers/assert';
 
 beforeEach(() => {
   document.body.innerHTML = '<div class="content"></div>';
@@ -44,7 +45,7 @@ describe('when browser is desktop', () => {
   it('does not hide the sidebar after a link is clicked', () => {
     const component = shallow(<Sidebar />);
 
-    component.find(Link).at(0).prop('onNavigate')();
+    assert(component.find(Link).at(0).prop('onNavigate'))();
     component.update();
 
     expect(component.find(Link)).toHaveLength(3);
@@ -81,7 +82,7 @@ describe('when browser is mobile', () => {
 
     component.find('.sidebar__toggle').simulate('click', {preventDefault});
 
-    component.find(Link).at(0).prop('onNavigate')();
+    assert(component.find(Link).at(0).prop('onNavigate'))();
     component.update();
 
     expect(component.find(Link)).not.toExist();

--- a/spec/javascript/_test_helpers/factories.ts
+++ b/spec/javascript/_test_helpers/factories.ts
@@ -25,7 +25,7 @@ function makeTag(attrs: Partial<Tag>): Tag {
   };
 }
 
-function makeTask(attrs: Partial<Task>): Task {
+function makeBaseTask(): BaseTask {
   nextTaskId += 1;
 
   return {
@@ -35,10 +35,8 @@ function makeTask(attrs: Partial<Task>): Task {
     estimateSeconds: null,
     loadingState: 'ready',
     parentTaskId: null,
-    pending: false,
     position: nextTaskId,
     priority: null,
-    releaseAt: null,
     repeatSeconds: null,
     skipCount: 0,
     status: 'active',
@@ -46,8 +44,40 @@ function makeTask(attrs: Partial<Task>): Task {
     tagNames: [],
     timeframe: null,
     title: `Task ${nextTaskId}`,
-    ...attrs,
   };
+}
+
+function makePendingTask(attrs: Partial<Task>): PendingTask {
+  if (attrs.hasOwnProperty('releaseAt') && !attrs.releaseAt) {
+    throw new Error('pending task must have releaseAt');
+  }
+
+  return {
+    ...makeBaseTask(),
+    releaseAt: '2020-03-20T11:24:42.892-07:00',
+    ...attrs,
+    pending: true,
+  };
+}
+
+function makeCurrentTask(attrs: Partial<Task>): CurrentTask {
+  if (attrs.releaseAt) {
+    throw new Error('non-pending task must not have releaseAt');
+  }
+
+  return {
+    ...makeBaseTask(),
+    ...attrs,
+    pending: false,
+    releaseAt: null,
+  };
+}
+
+function makeTask(attrs: Partial<Task>): Task {
+  if (attrs.pending) {
+    return makePendingTask(attrs);
+  }
+  return makeCurrentTask(attrs);
 }
 
 function makeTimeframe(attrs: Partial<Timeframe>): Timeframe {

--- a/spec/javascript/scratch/connect_with_scratch_spec.tsx
+++ b/spec/javascript/scratch/connect_with_scratch_spec.tsx
@@ -5,6 +5,7 @@ import {ActionCreator, Action} from 'redux';
 
 import connectWithScratch from 'src/scratch/connect_with_scratch';
 import createAppStore from 'src/create_app_store';
+import {assert} from 'src/_helpers/assert';
 import {createScratch, updateScratch} from 'src/scratch/action_creators';
 
 let container: ReactWrapper;
@@ -150,7 +151,7 @@ it('passes bound action creators to the wrapped component', () => {
     {updateFoo},
   );
 
-  testComponent.prop('updateFoo')('boo');
+  assert(testComponent.prop('updateFoo'))('boo');
 
   expect(store.dispatch).toHaveBeenCalledWith({type: 'blahboo'});
 });

--- a/spec/javascript/tag/selectors_spec.ts
+++ b/spec/javascript/tag/selectors_spec.ts
@@ -45,7 +45,7 @@ describe('getActiveTags', () => {
 
     it('does not return tag when field is set to a value', () => {
       const tag = makeTag({rules: [{check: 'isBlank', field: 'releaseAt'}]});
-      const task = makeTask({releaseAt: 'not blank'});
+      const task = makeTask({pending: true, releaseAt: 'not blank'});
       const state = makeState({tag: [tag], task: [task]});
 
       expect(getActiveTags(state)).toEqual([]);

--- a/spec/javascript/task/components/checkbox_spec.tsx
+++ b/spec/javascript/task/components/checkbox_spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import TaskCheckbox from 'src/task/components/checkbox';
+import {assert} from 'src/_helpers/assert';
 import {makeTask} from '_test_helpers/factories';
 
 const task = makeTask({});
@@ -40,7 +41,7 @@ it('adds a "checked" class to the label when checked', () => {
   const component = shallow(<TaskCheckbox {...props} checked />);
 
   const expectedClass = 'task-item__checkbox-display--checked';
-  const actualClass = component.find('label').prop('className');
+  const actualClass = assert(component.find('label').prop('className'));
   expect(actualClass.split(' ')).toContain(expectedClass);
 });
 
@@ -48,6 +49,6 @@ it('adds an "enabled" class to the label when not disabled', () => {
   const component = shallow(<TaskCheckbox {...props} />);
 
   const expectedClass = 'task-item__checkbox-display--enabled';
-  const actualClass = component.find('label').prop('className');
+  const actualClass = assert(component.find('label').prop('className'));
   expect(actualClass.split(' ')).toContain(expectedClass);
 });

--- a/spec/javascript/task/components/leaf_list_item_spec.tsx
+++ b/spec/javascript/task/components/leaf_list_item_spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import TaskLeafListItem from 'src/task/components/leaf_list_item';
+import {assert} from 'src/_helpers/assert';
 
 import {makeTask} from '_test_helpers/factories';
 
@@ -59,7 +60,8 @@ it('adds a priority class to title when task has a priority', () => {
   const overrides = {task: {...task, priority: 2}};
   const component = shallow(<TaskLeafListItem {...props} {...overrides} />);
 
-  const titleClasses = component.find('span').prop('className').split(' ');
+  const className = assert(component.find('span').prop('className'));
+  const titleClasses = className.split(' ');
   expect(titleClasses).toContain('task-item__title--priority-2');
 });
 

--- a/spec/javascript/task/components/parent_list_item_spec.tsx
+++ b/spec/javascript/task/components/parent_list_item_spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 
 import TaskParentListItem, {Props} from 'src/task/components/parent_list_item';
+import {assert} from 'src/_helpers/assert';
 
 import {makeTask} from '_test_helpers/factories';
 
@@ -37,7 +38,8 @@ it('adds a priority class to title when task has a priority', () => {
   const overrides = {task: {...task, priority: 2}};
   const component = shallow(<TaskParentListItem {...props} {...overrides} />);
 
-  const titleClasses = component.find('span').prop('className').split(' ');
+  const className = assert(component.find('span').prop('className'));
+  const titleClasses = className.split(' ');
   expect(titleClasses).toContain('task-item__title--priority-2');
 });
 


### PR DESCRIPTION
In order to get the `strictNullChecks` setting working, we've got to
convince TypeScript that these are really here.