### PR TITLE
TypeScript: split out taskReducer

### DIFF
--- a/app/javascript/src/task/reducer.ts
+++ b/app/javascript/src/task/reducer.ts
@@ -1,7 +1,7 @@
 import {keyBy} from 'lodash';
 import update from 'immutability-helper';
 
-import createBasicReducer from 'src/_common/create_basic_reducer';
+import grab from 'src/_helpers/grab';
 import {
   INIT,
   CREATE,
@@ -25,7 +25,7 @@ function processTask(task: Task): Task {
   return processedTask;
 }
 
-export default createBasicReducer({
+const operations = {
   [INIT]() {
     return {
       byId: {},
@@ -58,4 +58,12 @@ export default createBasicReducer({
   [UPDATE_META](previousState: TaskState, meta: TaskMeta) {
     return update(previousState, {meta: {$merge: meta}});
   },
-});
+};
+
+function taskReducer(previousState: TaskState | null, action: BasicAction) {
+  const operation = grab(operations, action.type);
+
+  return operation(previousState, action.payload);
+}
+
+export default taskReducer;

--- a/spec/javascript/_test_helpers/factories/task.ts
+++ b/spec/javascript/_test_helpers/factories/task.ts
@@ -27,7 +27,7 @@ function makePendingTask(attrs: Partial<Task>): PendingTask {
     throw new Error('pending task must have releaseAt');
   }
 
-  const releaseAt = '2020-03-20T11:24:42.892-07:00';
+  const releaseAt = attrs.releaseAt || '2020-03-20T11:24:42.892-07:00';
 
   return {
     ...makeBaseTask(),
@@ -57,4 +57,19 @@ function makeTask(attrs: Partial<Task>): Task {
   return makeCurrentTask(attrs);
 }
 
-export {makeTask};
+const defaultMeta: TaskMeta = {ajaxState: 'ready', newTask: {}};
+function makeTaskState(
+  {tasks = [], meta = {}}: {tasks?: Task[], meta?: Partial<TaskMeta>},
+): TaskState {
+  const byId: TasksById = tasks.reduce((result: TasksById, task) => {
+    result[task.id] = task;
+    return result;
+  }, {});
+
+  return {
+    byId,
+    meta: {...defaultMeta, ...meta},
+  };
+}
+
+export {makeTask, makeTaskState};

--- a/spec/javascript/task/reducer_spec.tsx
+++ b/spec/javascript/task/reducer_spec.tsx
@@ -4,6 +4,8 @@ import {
 } from 'src/task/action_creators';
 import taskReducer from 'src/task/reducer';
 
+import {makeTask, makeTaskState} from '_test_helpers/factories';
+
 describe(INIT, () => {
   it('sets up the basic structure for the store', () => {
     const expectedState = {
@@ -17,52 +19,41 @@ describe(INIT, () => {
 
 describe(SET, () => {
   it('replaces the existing tasks', () => {
-    const previousState = {
-      meta: 'foo',
-      byId: {dont: 'care'},
-    };
-    const task1 = {id: 1, title: 'a task'};
-    const task2 = {id: 5, title: 'wat task'};
+    const previousState = makeTaskState({tasks: [makeTask({})]});
+    const task1 = makeTask({title: 'a task'});
+    const task2 = makeTask({title: 'wat task'});
     const action = {type: SET, payload: [task2, task1]};
-    const expectedState = {
-      meta: 'foo',
-      byId: {
-        1: {...task1, estimateMinutes: 30, loadingState: 'ready'},
-        5: {...task2, estimateMinutes: 30, loadingState: 'ready'},
-      },
-    };
+    const expectedState = makeTaskState({tasks: [task1, task2]});
 
     expect(taskReducer(previousState, action)).toEqual(expectedState);
   });
 
   it('sets empty state when no tasks', () => {
-    const previousState = {
-      meta: 'foo',
-      byId: {dont: 'care'},
-    };
+    const previousState = makeTaskState({tasks: [makeTask({})]});
     const action = setTasks([]);
-    const expectedState = {meta: 'foo', byId: {}};
+    const expectedState = makeTaskState({tasks: []});
 
     expect(taskReducer(previousState, action)).toEqual(expectedState);
   });
 
   it('sets estimateMinutes for subTasks', () => {
-    const previousState = {byId: {}};
-    const task1 = {id: 1, title: 'a task', parentTaskId: 5};
-    const task2 = {id: 5, title: 'wat task'};
+    const previousState = makeTaskState({});
+    const task1 = makeTask({title: 'a task', parentTaskId: 5});
+    const task2 = makeTask({title: 'wat task'});
     const action = {type: SET, payload: [task1, task2]};
 
-    const expectedTask1 = {
-      ...task1,
-      estimateMinutes: 30,
-      loadingState: 'ready',
-    };
-    const expectedTask2 = {
-      ...task2,
-      estimateMinutes: 30,
-      loadingState: 'ready',
-    };
-    const expectedState = {byId: {1: expectedTask1, 5: expectedTask2}};
+    const expectedTasks: Task[] = [
+      {
+        ...task1,
+        estimateMinutes: 30,
+        loadingState: 'ready',
+      }, {
+        ...task2,
+        estimateMinutes: 30,
+        loadingState: 'ready',
+      },
+    ];
+    const expectedState = makeTaskState({tasks: expectedTasks});
 
     expect(taskReducer(previousState, action)).toEqual(expectedState);
   });
@@ -70,32 +61,23 @@ describe(SET, () => {
 
 describe(UPDATE, () => {
   it('updates the task in the store', () => {
-    const task = {id: 6, title: 'foo'};
-    const previousState = {byId: {6: task}};
-    const payload = {id: 6, title: 'bar', estimateSeconds: 60};
+    const task = makeTask({title: 'foo'});
+    const previousState = makeTaskState({tasks: [task]});
+    const payload = {id: task.id, title: 'bar', estimateSeconds: 60};
     const action = {type: UPDATE, payload};
-    const expectedTask = {
-      ...task,
-      ...payload,
-      estimateMinutes: 1,
-      loadingState: 'ready',
-    };
-    const expectedState = {byId: {6: expectedTask}};
+    const expectedTask = {...task, ...payload, estimateMinutes: 1};
+    const expectedState = makeTaskState({tasks: [expectedTask]});
 
     expect(taskReducer(previousState, action)).toEqual(expectedState);
   });
 
   it('preserves the loading state passed through the task attributes', () => {
-    const task = {id: 6, title: 'foo'};
-    const previousState = {byId: {6: task}};
-    const payload = {id: 6, loadingState: 'updating'};
+    const task = makeTask({title: 'foo'});
+    const previousState = makeTaskState({tasks: [task]});
+    const payload = {id: task.id, loadingState: 'updating'};
     const action = {type: UPDATE, payload};
-    const expectedTask = {
-      ...task,
-      estimateMinutes: 30,
-      loadingState: 'updating',
-    };
-    const expectedState = {byId: {6: expectedTask}};
+    const expectedTask: Task = {...task, loadingState: 'updating'};
+    const expectedState = makeTaskState({tasks: [expectedTask]});
 
     expect(taskReducer(previousState, action)).toEqual(expectedState);
   });
@@ -103,9 +85,9 @@ describe(UPDATE, () => {
 
 describe(UPDATE_META, () => {
   it('updates meta information in the state', () => {
-    const previousState = {meta: {foo: 'bar', baz: 'butz'}};
-    const action = {type: UPDATE_META, payload: {baz: 'bootz'}};
-    const expectedState = {meta: {foo: 'bar', baz: 'bootz'}};
+    const previousState = makeTaskState({meta: {ajaxState: 'fetching'}});
+    const action = {type: UPDATE_META, payload: {ajaxState: 'ready'}};
+    const expectedState = makeTaskState({meta: {ajaxState: 'ready'}});
 
     expect(taskReducer(previousState, action)).toEqual(expectedState);
   });


### PR DESCRIPTION
Stop using `createBasicReducer` because it's declared with `any` type,
making it hard for TypeScript to verify the shape of things coming in.
This necessitated also changing up the associated tests.