### PR TITLE
TypeScript: bring back createBasicReducer

### DIFF
--- a/app/javascript/src/_common/create_basic_reducer.ts
+++ b/app/javascript/src/_common/create_basic_reducer.ts
@@ -2,8 +2,8 @@ import grab from 'src/_helpers/grab';
 
 type ReducerMap = {[key: string]: Function};
 
-export default function createBasicReducer(operations: ReducerMap) {
-  function basicReducer(previousState: SubState | null, action: BasicAction) {
+export default function createBasicReducer<S, O>(operations: O) {
+  function basicReducer(previousState: S | null, action: BasicAction) {
     const operation = grab(operations, action.type);
 
     return operation(previousState, action.payload);

--- a/app/javascript/src/task/reducer.ts
+++ b/app/javascript/src/task/reducer.ts
@@ -1,7 +1,7 @@
 import {keyBy} from 'lodash';
 import update from 'immutability-helper';
 
-import grab from 'src/_helpers/grab';
+import createBasicReducer from 'src/_common/create_basic_reducer';
 import {
   INIT,
   CREATE,
@@ -60,10 +60,4 @@ const operations = {
   },
 };
 
-function taskReducer(previousState: TaskState | null, action: BasicAction) {
-  const operation = grab(operations, action.type);
-
-  return operation(previousState, action.payload);
-}
-
-export default taskReducer;
+export default createBasicReducer<TaskState, typeof operations>(operations);


### PR DESCRIPTION
Found a way to do this with generics.