### PR TITLE
CI: remove dependencies in CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,11 +126,7 @@ workflows:
   build_and_test:
     jobs:
       - lints
-      - javascript_tests:
-          requires: [lints]
-      - unit_tests:
-          requires: [lints]
-      - feature_tests_chrome_headless:
-          requires: [unit_tests, javascript_tests]
-      - feature_tests_chrome:
-          requires: [unit_tests, javascript_tests]
+      - javascript_tests
+      - unit_tests
+      - feature_tests_chrome_headless
+      - feature_tests_chrome


### PR DESCRIPTION
We don't have to worry about builds queueing anymore, so having these
dependencies only slows down the build.