### PR TITLE
Scratch: remove references to keyPrefix

### DIFF
--- a/app/javascript/src/task/components/draggable_task_row.tsx
+++ b/app/javascript/src/task/components/draggable_task_row.tsx
@@ -18,7 +18,6 @@ type DragProps = {
 
 type OwnProps = {
   deleteTask: Function,
-  keyPrefix: string;
   moveTask: Function;
   saveTaskPositions: Function,
   task: Task,
@@ -100,7 +99,6 @@ class DraggableTaskRow extends React.PureComponent<Props, any> {
     const {
       deleteTask,
       isDragging,
-      keyPrefix,
       status,
       task,
       timeframeSpace,
@@ -112,7 +110,6 @@ class DraggableTaskRow extends React.PureComponent<Props, any> {
       <TaskRow
         deleteTask={deleteTask}
         isDragging={isDragging}
-        keyPrefix={keyPrefix}
         status={status}
         task={task}
         timeframeSpace={timeframeSpace}
@@ -129,7 +126,6 @@ DraggableTaskRow.propTypes = {
   connectDropTarget: PropTypes.func.isRequired,
   deleteTask: PropTypes.func.isRequired,
   isDragging: PropTypes.bool.isRequired,
-  keyPrefix: PropTypes.string.isRequired,
   task: taskShape.isRequired,
   updateTask: PropTypes.func.isRequired,
   status: PropTypes.string,

--- a/app/javascript/src/task/components/list_view.tsx
+++ b/app/javascript/src/task/components/list_view.tsx
@@ -150,7 +150,6 @@ class TaskListView extends React.Component<Props, any> {
     return (
       <DraggableTaskRow
         key={task.id}
-        keyPrefix={`${status}TimeframeSection`}
         task={task}
         moveTask={this.moveTask}
         saveTaskPositions={this.saveTaskPositions}

--- a/app/javascript/src/task/components/show_view.tsx
+++ b/app/javascript/src/task/components/show_view.tsx
@@ -83,7 +83,7 @@ class TaskShowView extends React.Component<Props, any> {
     return (
       <section>
         <ParentTaskBreadCrumbs taskId={task.parentTaskId} />
-        <h2><TaskEditTitleForm keyPrefix={'showView'} task={task} /></h2>
+        <h2><TaskEditTitleForm task={task} /></h2>
         <div>{repeatString(task)}</div>
         <div>{estimateString(task)}</div>
         <div>{priorityString(task)}</div>

--- a/app/javascript/src/task/components/sub_tasks_table.tsx
+++ b/app/javascript/src/task/components/sub_tasks_table.tsx
@@ -16,7 +16,6 @@ function taskRows(tasks: Task[], {updateTask, deleteTask}: FunctionProps) {
   return tasks.map(task => (
     <TaskRow
       key={task.id}
-      keyPrefix={'subTasksTable'}
       task={task}
       updateTask={updateTask}
       deleteTask={deleteTask}

--- a/app/javascript/src/task/components/task_row.tsx
+++ b/app/javascript/src/task/components/task_row.tsx
@@ -14,7 +14,6 @@ const BUTTON_CLASS = 'btn btn-link tasks-table__action';
 
 export type Props = {
   deleteTask: Function,
-  keyPrefix: string,
   task: Task,
   updateTask: Function,
   isDragging?: boolean,
@@ -180,7 +179,7 @@ class TaskRow extends React.PureComponent<Props, any> {
   }
 
   render() {
-    const {keyPrefix, task, timeframesEnabled} = this.props;
+    const {task, timeframesEnabled} = this.props;
 
     return (
       <tr className={this.className()} ref={this.storeDOMNode}>
@@ -189,7 +188,7 @@ class TaskRow extends React.PureComponent<Props, any> {
             {'DONE'}
           </button>
         </td>
-        <td><TaskEditTitleForm keyPrefix={keyPrefix} task={task} /></td>
+        <td><TaskEditTitleForm task={task} /></td>
         <td><TaskEditIcon task={task} /></td>
         <td>{this.taskEstimate()}</td>
         <td>{this.emblems()}</td>
@@ -217,7 +216,6 @@ class TaskRow extends React.PureComponent<Props, any> {
 
 TaskRow.propTypes = {
   deleteTask: PropTypes.func.isRequired,
-  keyPrefix: PropTypes.string.isRequired,
   task: taskShape.isRequired,
   updateTask: PropTypes.func.isRequired,
   isDragging: PropTypes.bool,

--- a/app/javascript/src/task/components/task_title.tsx
+++ b/app/javascript/src/task/components/task_title.tsx
@@ -72,7 +72,7 @@ class TaskTitle extends React.Component<Props, any> {
                 </td>
                 <td className='col-xs-10 title'>
                   <div className='col-xs-10 col-xs-offset-1'>
-                    <TaskEditTitleForm keyPrefix={'focusView'} task={task} />
+                    <TaskEditTitleForm task={task} />
                   </div>
 
                   <div className='col-xs-1'>

--- a/app/javascript/src/timeframe/components/section.tsx
+++ b/app/javascript/src/timeframe/components/section.tsx
@@ -30,7 +30,6 @@ class TimeframeSection extends React.Component<Props, any> {
         timeframeSpace={timeframeSpace}
         task={task}
         key={task.id}
-        keyPrefix={`${timeframe.name}TimeframeSection`}
         updateTask={updateTask}
         deleteTask={deleteTask}
       />
@@ -47,7 +46,6 @@ class TimeframeSection extends React.Component<Props, any> {
         timeframeSpace={timeframeSpace}
         task={task}
         key={task.id}
-        keyPrefix={`${timeframe.name}PendingTimeframeSection`}
         updateTask={updateTask}
         deleteTask={deleteTask}
       />

--- a/spec/javascript/task/components/task_row_spec.tsx
+++ b/spec/javascript/task/components/task_row_spec.tsx
@@ -8,7 +8,6 @@ import TaskRow, {Props} from 'src/task/components/task_row';
 const props: Props = {
   deleteTask: jest.fn(),
   updateTask: jest.fn(),
-  keyPrefix: 'testPrefix',
   task: makeTask(),
 };
 


### PR DESCRIPTION
These are no longer necessary since they were used for `scratch` and
that has been removed.