### PR TITLE
Disable `no-unused-vars` rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -39,6 +39,7 @@ rules:
   '@typescript-eslint/member-delimiter-style': off
   '@typescript-eslint/no-empty-interface': off
   '@typescript-eslint/no-explicit-any': off
+  '@typescript-eslint/no-unused-vars': off
   '@typescript-eslint/no-var-requires': off
   class-methods-use-this: off
   fp/no-class: off


### PR DESCRIPTION
It doesn't seem to be working correctly. It's warning for imported
`Props` types that are used in the file.
