### PR TITLE
remove flexible version constraint for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "yarn-deduplicate": "^3.0.0"
   },
   "engines": {
-    "node": ">=14.13.1"
+    "node": "14.13.1"
   },
   "license": "UNLICENSED",
   "scripts": {


### PR DESCRIPTION
Depfu doesn't seem to smart about the `>=` so see if `~>` works better.
