### PR TITLE
TypeScript: enable a couple more strict options

### DIFF
--- a/app/javascript/src/task/components/edit_title_form.tsx
+++ b/app/javascript/src/task/components/edit_title_form.tsx
@@ -17,7 +17,7 @@ type State = {
 }
 
 class TaskEditTitleForm extends React.Component<Props, State> {
-  submitting: boolean;
+  submitting = false;
 
   input: any;
 

--- a/spec/javascript/_test_helpers/fake_notification.ts
+++ b/spec/javascript/_test_helpers/fake_notification.ts
@@ -1,29 +1,27 @@
-class FakeNotification {
-  message: string;
+class FakeNotification implements Notification {
+  actions = [];
 
-  actions: NotificationAction[];
+  badge = '';
 
-  badge: string;
+  body = '';
 
-  body: string;
+  data = null;
 
-  data: null;
+  dir: NotificationDirection = 'auto';
 
-  dir: NotificationDirection;
+  icon = '';
 
-  icon: string;
+  image = '';
 
-  image: string;
+  lang = '';
 
-  lang: string;
+  onclick = null;
 
-  onclick: null;
+  onclose = null;
 
-  onclose: null;
+  onerror = null;
 
-  onerror: null;
-
-  onshow: null;
+  onshow = null;
 
   renotify = false;
 
@@ -39,14 +37,14 @@ class FakeNotification {
 
   vibrate = [];
 
-  isOpen = true;
+  isOpen = true; // custom
 
   static requestPermission() {
     return Promise.resolve('granted');
   }
 
-  constructor(message: string) {
-    this.message = message;
+  constructor(title: string) {
+    this.title = title;
     this.isOpen = true;
   }
 

--- a/spec/javascript/notification/action_creators_spec.ts
+++ b/spec/javascript/notification/action_creators_spec.ts
@@ -43,7 +43,7 @@ describe('addNotification', () => {
       const {notification} = action.payload;
 
       expect(notification).toBeInstanceOf(FakeNotification);
-      expect(notification.message).toBe('my message');
+      expect(notification.title).toBe('my message');
     });
 
     it('adds a custom onClick handler to the notification', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "//": {
-    "strictPropertyInitialization": true,
+    "strictFunctionTypes": true,
     "strict": true
   },
   "compilerOptions": {
@@ -20,7 +20,9 @@
       "src/*": ["app/javascript/src/*"]
     },
     "sourceMap": true,
+    "strictBindCallApply": true,
     "strictNullChecks": true,
+    "strictPropertyInitialization": true,
     "target": "es5",
     "jsx": "react"
   },


### PR DESCRIPTION
`strictPropertyInitialization` ensures that a property is set to the
specified type. If you specify something as `thing: string` but *don't*
set it in the constructor or when declaring the property, the rule will
complain.

Not sure what `strictBindCallApply` does, exactly, but we've already
satisfied it.
