### PR TITLE
TypeScript: fix more strictFunctionTypes errors

### DIFF
--- a/app/javascript/src/tag/selectors.ts
+++ b/app/javascript/src/tag/selectors.ts
@@ -75,7 +75,7 @@ const getSelectedTag = createSelector(
 );
 
 const getNextActiveTask = createSelector(
-  [getSelectedTag], (selectedTag: Tag) => selectedTag.tasks[0],
+  [getSelectedTag], (selectedTag: Tag | undefined) => selectedTag?.tasks[0],
 );
 
 export {

--- a/app/javascript/src/task/containers/focus_view.ts
+++ b/app/javascript/src/task/containers/focus_view.ts
@@ -5,7 +5,7 @@ import TaskFocusView from 'src/task/components/focus_view';
 
 function mapStateToProps(state: State) {
   const {ajaxState} = state.task.meta;
-  const task = ajaxState === 'ready' ? getNextActiveTask(state) : null;
+  const task = getNextActiveTask(state);
 
   return {task, ajaxState};
 }


### PR DESCRIPTION
`selectedTag` can be `undefined` when page is still loading, so we need
to account for it.
