### PR TITLE
TypeScript: fix newTask title

### DIFF
--- a/app/javascript/@types/task.d.ts
+++ b/app/javascript/@types/task.d.ts
@@ -79,7 +79,7 @@ type BulkTaskStoreType = {
 
 type TaskMeta = {
   ajaxState: 'taskSaving' | 'fetching' | 'ready';
-  newTask: Partial<Task>;
+  newTask: NewTask;
 };
 
 type AjaxTask = {

--- a/spec/javascript/_test_helpers/factories/task.ts
+++ b/spec/javascript/_test_helpers/factories/task.ts
@@ -59,7 +59,7 @@ function makeTask(attrs: Partial<Task> = {}): Task {
   return makeCurrentTask(attrs);
 }
 
-const defaultMeta: TaskMeta = {ajaxState: 'ready', newTask: {}};
+const defaultMeta: TaskMeta = {ajaxState: 'ready', newTask: {title: ''}};
 function makeTaskState(
   {tasks = [], meta = {}}: {tasks?: Task[], meta?: Partial<TaskMeta>} = {},
 ): TaskState {


### PR DESCRIPTION
`strictFunctionTypes` complained in places that `newTask.title` could be
`undefined`. This makes it so that is not true.
