### PR TITLE
TypeScript: satisfy strictFunctionTypes with taskId

### DIFF
--- a/app/javascript/src/task/containers/parent_task_bread_crumbs.tsx
+++ b/app/javascript/src/task/containers/parent_task_bread_crumbs.tsx
@@ -40,7 +40,10 @@ class ParentTaskBreadCrumbs extends React.Component<ComponentProps, any> {
 ParentTaskBreadCrumbs.propTypes = {task: taskShape};
 
 function mapStateToProps(state: State, ownProps: ContainerProps) {
-  return {task: ownProps.taskId && state.task.byId[ownProps.taskId]};
+  const {taskId} = ownProps;
+  let task;
+  if (taskId !== null) { task = state.task.byId[taskId]; }
+  return {task};
 }
 
 const ParentTaskBreadCrumbsContainer =

--- a/config/jest.json
+++ b/config/jest.json
@@ -5,10 +5,10 @@
   "coverageReporters": ["json", "lcov"],
   "coverageThreshold": {
     "global": {
-      "statements": 87.07,
-      "branches": 75.67,
-      "functions": 79.57,
-      "lines": 88.73
+      "statements": 87.13,
+      "branches": 76.4,
+      "functions": 79.79,
+      "lines": 88.8
     }
   },
   "errorOnDeprecated": true,

--- a/spec/javascript/task/containers/parent_task_bread_crumbs_spec.tsx
+++ b/spec/javascript/task/containers/parent_task_bread_crumbs_spec.tsx
@@ -1,29 +1,44 @@
 import React from 'react';
+import {createStore} from 'redux';
 import {shallow} from 'enzyme';
 
-import {
-  ParentTaskBreadCrumbs,
-} from 'src/task/containers/parent_task_bread_crumbs';
+import ParentTaskBreadCrumbsContainer, {ParentTaskBreadCrumbs}
+  from 'src/task/containers/parent_task_bread_crumbs';
 
-import {makeTask} from '_test_helpers/factories';
+import {makeState, makeTask} from '_test_helpers/factories';
 
-it('renders nothing when there is no task', () => {
-  const component = shallow(<ParentTaskBreadCrumbs />);
+describe('ParentTaskBreadCrumbs', () => {
+  it('renders nothing when there is no task', () => {
+    const component = shallow(<ParentTaskBreadCrumbs />);
 
-  expect(component.type()).toBeNull();
+    expect(component.type()).toBeNull();
+  });
+
+  it('renders a link to the task when present', () => {
+    const task = makeTask();
+    const component = shallow(<ParentTaskBreadCrumbs task={task} />);
+
+    expect(component.find('TaskLink')).toHaveProp('task', task);
+  });
+
+  it('renders a parent task link recursively when tree goes deeper', () => {
+    const task = makeTask({title: 'some parent', parentTaskId: 5});
+    const component = shallow(<ParentTaskBreadCrumbs task={task} />);
+    const container = component.find('Connect(ParentTaskBreadCrumbs)');
+
+    expect(container).toHaveProp('taskId', 5);
+  });
 });
 
-it('renders a link to the task when present', () => {
-  const task = makeTask();
-  const component = shallow(<ParentTaskBreadCrumbs task={task} />);
+describe('ParentTaskBreadCrumbsContainer', () => {
+  it('renders the component with a task when taskId is present', () => {
+    const task = makeTask();
+    const state = makeState({task: [task]});
+    const props = {store: createStore(() => state), taskId: task.id};
 
-  expect(component.find('TaskLink')).toHaveProp('task', task);
-});
+    const container = shallow(<ParentTaskBreadCrumbsContainer {...props} />);
+    const component = container.find('ParentTaskBreadCrumbs');
 
-it('renders a parent task link recursively when tree goes deeper', () => {
-  const task = makeTask({title: 'some parent', parentTaskId: 5});
-  const component = shallow(<ParentTaskBreadCrumbs task={task} />);
-  const container = component.find('Connect(ParentTaskBreadCrumbs)');
-
-  expect(container).toHaveProp('taskId', 5);
+    expect(component).toHaveProp('task', task);
+  });
 });


### PR DESCRIPTION
It's complaining that `taskId` could be `0`, which is falsey, so the
task would end up being `0` instead of `null` or an actual task. Task
ids cannot be 0, but we refactored it to make TypeScript happy.
