### PR TITLE
Upgrades: remove bullet gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,6 @@ group :development do
 end
 
 group :development, :test do
-  gem 'bullet'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'guard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,9 +73,6 @@ GEM
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
     builder (3.2.4)
-    bullet (6.1.0)
-      activesupport (>= 3.0.0)
-      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.34.0)
       addressable
@@ -360,7 +357,6 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
-    uniform_notifier (1.13.0)
     vcr (6.0.0)
     web-console (4.1.0)
       actionview (>= 6.0.0)
@@ -396,7 +392,6 @@ DEPENDENCIES
   better_errors
   bootsnap
   bootstrap-sass
-  bullet
   capybara
   capybara-screenshot
   dalli

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,5 +1,0 @@
-if defined?(Bullet)
-  Bullet.enable = true
-  Bullet.rails_logger = true
-  # Bullet.raise = true
-end


### PR DESCRIPTION
Not making a ton of use of this, and it's not very well maintained.
Rails 6.1 added a nice strict query thing, so that should also help
reduce N+1 queries.
