### PR TITLE
TypeScript: enable all strict settings

### DIFF
--- a/spec/javascript/_test_helpers/factories/state.ts
+++ b/spec/javascript/_test_helpers/factories/state.ts
@@ -1,11 +1,25 @@
 import appReducer from 'src/app_reducer';
 
-function makeState(attrs: {[key in keyof State]?: any} = {}): State {
-  return Object.keys(attrs).reduce((state: State, key: StateKey) => {
+const stateKeys = ['common', 'notification', 'route', 'tag', 'task', 'user'];
+
+function isStateKey(value: string): value is StateKey {
+  return stateKeys.includes(value);
+}
+function makeState(
+  attrs: {[key in keyof State]?: any} = {},
+  previousState: State | null = null,
+): State {
+  let state: State = previousState || appReducer(null, null);
+
+  Object.keys(attrs).forEach((key: string) => {
+    if (!isStateKey(key)) { throw new Error(`invalid key ${key}`); }
+
     const action = {type: `${key}/SET`, payload: attrs[key]};
 
-    return {...state, ...appReducer(state, action)};
-  }, {});
+    state = {...state, ...appReducer(state, action)};
+  });
+
+  return state;
 }
 
 export {makeState};

--- a/spec/javascript/app_reducer_spec.ts
+++ b/spec/javascript/app_reducer_spec.ts
@@ -32,7 +32,8 @@ describe('appReducer', () => {
       const notificationState = {notificationsEnabled: true};
       const result = reducer(makeState({user: notificationState}), action);
 
-      expect(result).toEqual({user: {...notificationState, goober: 'globber'}});
+      const expected = {user: {...notificationState, goober: 'globber'}};
+      expect(result).toMatchObject(expected);
     });
   });
 

--- a/spec/javascript/tag/selectors_spec.ts
+++ b/spec/javascript/tag/selectors_spec.ts
@@ -109,12 +109,12 @@ describe('getNextActiveTask', () => {
     expect(getNextActiveTask(state)).toEqual(task1);
 
     task2 = {...task2, timeframe: 'today'};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task2);
 
     task2 = {...task2, status: 'pending'};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task1);
   });
@@ -131,12 +131,12 @@ describe('getNextActiveTask', () => {
     expect(getNextActiveTask(state)).toEqual(task1);
 
     task2 = {...task2, priority: 2};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task2);
 
     task2 = {...task2, status: 'pending'};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task1);
   });
@@ -153,12 +153,12 @@ describe('getNextActiveTask', () => {
     expect(getNextActiveTask(state)).toEqual(task1);
 
     task2 = {...task2, position: 2};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task2);
 
     task2 = {...task2, status: 'pending'};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task1);
   });
@@ -175,27 +175,27 @@ describe('getNextActiveTask', () => {
     expect(getNextActiveTask(state)).toEqual(task1);
 
     task2 = {...task2, position: 2};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task1);
 
     task2 = {...task2, priority: 1};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task1);
 
     task2 = {...task2, timeframe: 'today'};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task2);
 
     task2 = {...task2, priority: null};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task2);
 
     task2 = {...task2, position: 35};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task1);
   });
@@ -220,7 +220,7 @@ describe('getNextActiveTask', () => {
     expect(getNextActiveTask(state)).toEqual(task1);
 
     task2 = {...task2, tagIds: [tag1.id]};
-    state = {...state, ...makeState({task: [task1, task2]})};
+    state = makeState({task: [task1, task2]}, state);
 
     expect(getNextActiveTask(state)).toEqual(task2);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,4 @@
 {
-  "//": {
-    "strictFunctionTypes": true,
-    "strict": true
-  },
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
     "baseUrl": ".",
@@ -13,16 +9,11 @@
     "lib": ["es2017", "dom"],
     "module": "es6",
     "moduleResolution": "node",
-    "alwaysStrict": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
     "paths": {
       "src/*": ["app/javascript/src/*"]
     },
     "sourceMap": true,
-    "strictBindCallApply": true,
-    "strictNullChecks": true,
-    "strictPropertyInitialization": true,
+    "strict": true,
     "target": "es5",
     "jsx": "react"
   },


### PR DESCRIPTION
Needed to refactor the `makeState` factory to be more strict around the
shape of the state being passed in.
