### PR TITLE
fix cache setup

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -24,17 +24,11 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp/caching-dev.txt').exist?
-    config.action_controller.perform_caching = true
-    config.action_controller.enable_fragment_cache_logging = true
+  config.action_controller.perform_caching = true
+  config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :memory_store
-    config.public_file_server.headers = { 'Cache-Control' => "public, max-age=#{2.days.to_i}" }
-  else
-    config.action_controller.perform_caching = false
-
-    config.cache_store = :null_store
-  end
+  config.cache_store = :mem_cache_store
+  config.public_file_server.headers = { 'Cache-Control' => "public, max-age=#{2.days.to_i}" }
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.log_tags = [:request_id]
 
   # Use a different cache store in production.
-  config.cache_store = :dalli_store,
+  config.cache_store = :mem_cache_store,
                        ENV.fetch('MEMCACHIER_SERVERS').split(','),
                        {
                          username: ENV.fetch('MEMCACHIER_USERNAME'),

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :mem_cache_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
This updates the cache store from `:dalli_store` to `:mem_cache_store`.
Not sure when this changed, but it failed the production deploy. I also
updated dev and test mode to enable caching so that hopefully these
things can be caught sooner.
