### PR TITLE
React: rename methods with `UNSAFE_` prefix

### DIFF
--- a/app/javascript/src/_common/components/sidebar.tsx
+++ b/app/javascript/src/_common/components/sidebar.tsx
@@ -19,7 +19,7 @@ class Sidebar extends React.Component<any, any> {
     this.state = {visible: false};
   }
 
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     this.mediaQueryList = window.matchMedia('(max-width: 600px)');
     this.mediaQueryList.addListener(this.updateScreenSize);
     this.updateScreenSize();

--- a/app/javascript/src/task/components/edit_title_form.tsx
+++ b/app/javascript/src/task/components/edit_title_form.tsx
@@ -30,7 +30,7 @@ class TaskEditTitleForm extends React.Component<Props, State> {
     };
   }
 
-  componentWillReceiveProps(newProps: Props) {
+  UNSAFE_componentWillReceiveProps(newProps: Props) {
     const {task} = this.props;
 
     if (newProps.task.id !== task.id) {

--- a/app/javascript/src/task/components/list_view.tsx
+++ b/app/javascript/src/task/components/list_view.tsx
@@ -44,7 +44,7 @@ class TaskListView extends React.Component<Props, any> {
     autobind(this);
   }
 
-  componentWillReceiveProps(nextProps: Props) {
+  UNSAFE_componentWillReceiveProps(nextProps: Props) {
     const {currentTasks, pendingTasks} = nextProps;
     this.setState({currentTasks, pendingTasks});
   }

--- a/app/javascript/src/task/components/show_view.tsx
+++ b/app/javascript/src/task/components/show_view.tsx
@@ -50,7 +50,7 @@ class TaskShowView extends React.Component<Props, any> {
     this.setTask(task);
   }
 
-  componentWillReceiveProps({task}: Props) {
+  UNSAFE_componentWillReceiveProps({task}: Props) {
     this.setTask(task);
   }
 


### PR DESCRIPTION
This satisfies warnings from React.
