### PR TITLE
NoReact: fix task page for direct navigation

### DIFF
--- a/app/javascript/@types/state.d.ts
+++ b/app/javascript/@types/state.d.ts
@@ -6,9 +6,13 @@ type NotificationState = {
   currentTask: Notification;
 };
 
+type RouteParams = {
+  [key: string]: string;
+}
+
 type RouteState = {
   name: string;
-  params: {[key: string]: string};
+  params: RouteParams;
 };
 
 type TagState = {

--- a/app/javascript/src/task/selectors.ts
+++ b/app/javascript/src/task/selectors.ts
@@ -15,6 +15,10 @@ const timeframePositions = {
   century: 8,
 };
 
+const nullTask = {
+  tagNames: [],
+} as const;
+
 function timeframePosition(task: Task) {
   const {timeframe} = task;
 
@@ -50,6 +54,10 @@ function mapTasksToParentId(tasksById: TasksById): TasksByParentId {
 
 function grabLeafTasks(orderedTasks: Task[], tasksByParentId: TasksByParentId) {
   return orderedTasks.filter(task => tasksByParentId[task.id].length === 0);
+}
+
+function grabCurrentTask(tasksById: TasksById, routeParams: RouteParams) {
+  return tasksById[routeParams.taskId] || nullTask;
 }
 
 const getTasksById = createSelector(
@@ -88,12 +96,12 @@ const getActiveTasks = createSelector(
 const getCurrentTask = createSelector(
   getTasksById,
   getRouteParams,
-  (tasksById: TasksById, routeParams) => tasksById[routeParams.taskId],
+  grabCurrentTask,
 );
 
 const getCurrentSubTasks = createSelector(
   [getCurrentTask, getTasksByParentId],
-  (currentTask: Task, tasksByParentId) => tasksByParentId[currentTask.id],
+  (currentTask: Task, tasksByParentId) => tasksByParentId[currentTask.id] || [],
 );
 
 export {

--- a/spec/javascript/task/selectors_spec.tsx
+++ b/spec/javascript/task/selectors_spec.tsx
@@ -16,11 +16,11 @@ describe('getCurrentTask', () => {
     expect(getCurrentTask(state)).toEqual(task);
   });
 
-  it('returns no task when task in route is not present', () => {
+  it('returns null task when task in route is not present', () => {
     const task = makeTask({title: 'foo task'});
     const state = makeState({route: {params: {taskId: 0}}, task: [task]});
 
-    expect(getCurrentTask(state)).toBeUndefined();
+    expect(getCurrentTask(state)).toEqual({tagNames: []});
   });
 });
 


### PR DESCRIPTION
Right now the task/show page is broken when you navigate directly to it
in the URL. It depends on JavaScript setting the current task on another
page before navigation, which is kind of gross. This fills in with a
`nullTask` while the task is being loaded from the server. Not perfect,
but the goal is to replace this with a fully server rendered page at
some point, so an okay stopgap.
