### PR TITLE
NoReact: remove click handler from Link

### DIFF
--- a/app/javascript/src/route/components/link.tsx
+++ b/app/javascript/src/route/components/link.tsx
@@ -1,7 +1,7 @@
 import autobind from 'class-autobind';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {MouseEvent} from 'react';
+import React from 'react';
 import {mapValues} from 'lodash';
 
 import {findRoute} from 'src/route/helpers';
@@ -12,7 +12,6 @@ type Props = {
   onNavigate?: Function;
   params?: {[key: string]: string | number};
   routeName: string;
-  setRoute: Function;
   to: string;
 };
 
@@ -20,16 +19,6 @@ class Link extends React.Component<Props, any> {
   constructor(props: Props) {
     super(props);
     autobind(this);
-  }
-
-  navigate(event: MouseEvent) {
-    event.preventDefault();
-
-    const {onNavigate, params, setRoute, to} = this.props;
-
-    setRoute({name: to, ...params});
-
-    if (onNavigate) { onNavigate(); }
   }
 
   path() {
@@ -53,11 +42,7 @@ class Link extends React.Component<Props, any> {
     const {children} = this.props;
 
     return (
-      <a
-        href={this.path()}
-        className={this.className()}
-        onClick={this.navigate}
-      >
+      <a href={this.path()} className={this.className()}>
         {children}
       </a>
     );
@@ -70,7 +55,6 @@ Link.propTypes = {
     PropTypes.element,
   ]).isRequired,
   routeName: PropTypes.string.isRequired,
-  setRoute: PropTypes.func.isRequired,
   to: PropTypes.string.isRequired,
   baseClass: PropTypes.string,
   className: PropTypes.string,

--- a/app/javascript/src/route/containers/link.ts
+++ b/app/javascript/src/route/containers/link.ts
@@ -2,10 +2,9 @@ import {connect} from 'react-redux';
 
 import Link from 'src/route/components/link';
 import {getRouteName} from 'src/route/selectors';
-import {setRoute} from 'src/route/action_creators';
 
 function mapStateToProps(state: State) {
   return {routeName: getRouteName(state)};
 }
 
-export default connect(mapStateToProps, {setRoute})(Link);
+export default connect(mapStateToProps)(Link);

--- a/spec/features/smart_tags_spec.rb
+++ b/spec/features/smart_tags_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe 'editing smart tags', js: true do
     tag = create(:tag, name: 'my tag', user: user)
     visit '/tags'
 
-    sidebar.close
-
     expect(page).to have_selector('.tag-row', count: 3)
     within('.tag-row', text: tag.name) { click_link('Edit') }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,6 @@ RSpec.configure do |config|
   config.before(:each, type: :feature) do
     visit '/'
     page.execute_script(File.read(support_path.join('disable_animations.js')))
-    sidebar.close
   end
 end
 
@@ -99,13 +98,11 @@ def feature_login_as(user)
   click_button 'Login'
   expect(page).to have_content("Logged in as #{user.account.email}")
   page.execute_script(File.read(support_path.join('disable_animations.js')))
-  sidebar.close
 end
 
 def add_task(task_title)
   fill_in 'new-title', with: task_title
   click_button 'Add Task'
-  # binding.pry
   expect(page).to have_content('Task added')
   expect(page).not_to have_content('Task added')
 end

--- a/spec/support/wrappers/sidebar.rb
+++ b/spec/support/wrappers/sidebar.rb
@@ -12,23 +12,9 @@ module Questlog
         self.element = find('.sidebar')
       end
 
-      def close
-        expect(page).to have_link('ALL TASKS')
-        element.find('.sidebar__toggle--visible').click
-        expect(page).to have_no_link('ALL TASKS')
-      end
-
-      def open
-        expect(page).to have_no_link('ALL TASKS')
-        element.find('.sidebar__toggle--hidden').click
-        expect(page).to have_link('ALL TASKS')
-      end
-
       def click(link_text)
-        open
-        element.find('a', text: link_text).click
+        click_link(link_text)
         expect(page).to have_selector('.sidebar__link--active', text: link_text)
-        close
       end
     end
 


### PR DESCRIPTION
This removes the `onClick` handler from the `Link` component, making it
so that clicking a link no longer makes an ajax request, but instead
does a synchronous server request. This effectively splits all of the
different routes so that they do not have persistent client-side state
across page navigations.
