### PR TITLE
NoReact: update tags synchronously

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,18 @@
+class TagsController < ApplicationController
+  def update
+    tag = current_user.tags.find(params[:id])
+    Tag::Update.(tag, tag_params)
+    redirect_to '/tags'
+  end
+
+  private
+
+  def tag_params
+    params
+      .require(:tag)
+      .permit(rules: %i[check field])
+      .to_h
+      .merge(user: current_user)
+      .symbolize_keys
+  end
+end

--- a/app/javascript/src/tag/action_creators.ts
+++ b/app/javascript/src/tag/action_creators.ts
@@ -1,29 +1,12 @@
-import {Action, Dispatch} from 'redux';
+import {Action} from 'redux';
 import {ThunkAction} from 'redux-thunk';
-
-import {ajaxPut} from 'src/_helpers/ajax';
-
-const BASE_PATH = '/api/v1/tags';
 
 const INIT = 'tag/INIT';
 const SET = 'tag/SET';
-const UPDATE = 'tag/UPDATE';
 const UPSERT = 'tag/UPSERT';
 
 function setTags(payload: Tag[]) {
   return {type: SET, payload};
-}
-
-function updateTagPlain(id: number, payload: AjaxTag) {
-  return {type: UPDATE, payload: {id, ...payload}};
-}
-
-function updateTag(id: number, payload: AjaxTag) {
-  return async function updateTagThunk(dispatch: Dispatch) {
-    await ajaxPut(`${BASE_PATH}/${id}`, {tag: payload});
-
-    dispatch(updateTagPlain(id, payload));
-  };
 }
 
 function upsertTagPlain(payload: AjaxTag) {
@@ -36,5 +19,5 @@ function upsertTags(tags: AjaxTag[]): ThunkAction<void, State, null, Action> {
   };
 }
 
-export {INIT, SET, UPDATE, UPSERT};
-export {setTags, updateTag, upsertTagPlain, upsertTags};
+export {INIT, SET, UPSERT};
+export {setTags, upsertTagPlain, upsertTags};

--- a/app/javascript/src/tag/components/rule_row.tsx
+++ b/app/javascript/src/tag/components/rule_row.tsx
@@ -58,7 +58,7 @@ class RuleRow extends React.Component<Props, any> {
     const defaultValue = checks.includes(rule.check) ? rule.check : checks[0];
 
     return (
-      <select defaultValue={defaultValue}>
+      <select name={'tag[rules[][check]]'} defaultValue={defaultValue}>
         {
           checks.map(check => (
             <option value={check} key={check}>
@@ -86,7 +86,11 @@ class RuleRow extends React.Component<Props, any> {
 
     return (
       <li>
-        <select defaultValue={rule.field} onChange={this.updateFieldValue}>
+        <select
+          name={'tag[rules[][field]]'}
+          defaultValue={rule.field}
+          onChange={this.updateFieldValue}
+        >
           {this.fieldOptions()}
         </select>
         {this.checksDropdown()}

--- a/app/javascript/src/tag/containers/edit_view.ts
+++ b/app/javascript/src/tag/containers/edit_view.ts
@@ -1,13 +1,9 @@
 import {connect} from 'react-redux';
 import TagEditView from 'src/tag/components/edit_view';
 import {getSelectedTag} from 'src/tag/selectors';
-import {setRoute} from 'src/route/action_creators';
-import {updateTag} from 'src/tag/action_creators';
 
 function mapStateToProps(state: State) {
   return {tag: getSelectedTag(state)};
 }
 
-const actionCreators = {setRoute, updateTag};
-
-export default connect(mapStateToProps, actionCreators)(TagEditView);
+export default connect(mapStateToProps)(TagEditView);

--- a/app/javascript/src/tag/reducer.ts
+++ b/app/javascript/src/tag/reducer.ts
@@ -3,7 +3,7 @@ import {keyBy} from 'lodash';
 
 import createBasicReducer from 'src/_common/create_basic_reducer';
 
-import {INIT, SET, UPDATE, UPSERT} from 'src/tag/action_creators';
+import {INIT, SET, UPSERT} from 'src/tag/action_creators';
 
 const operations = {
   [INIT]() {
@@ -12,14 +12,6 @@ const operations = {
 
   [SET](previousState: TagState, tags: Tag[]) {
     return {...previousState, byId: keyBy(tags, 'id')};
-  },
-
-  [UPDATE](previousState: TagState, tagAttrs: Tag) {
-    if (!previousState.byId[tagAttrs.id]) {
-      throw new Error(`no tag found for id ${tagAttrs.id}`);
-    }
-
-    return update(previousState, {byId: {[tagAttrs.id]: {$merge: tagAttrs}}});
   },
 
   [UPSERT](previousState: TagState, tag: Tag) {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
     resources :free_accounts, only: %i[new create]
     resources :charges, only: %i[new create]
+    resources :tags, only: %i[update]
     get '/what', to: 'pages#what'
     get '/privacy', to: 'pages#privacy'
 

--- a/spec/controllers/tags_controller/update_spec.rb
+++ b/spec/controllers/tags_controller/update_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe TagsController, '#update' do
+  it 'updates the tag rules' do
+    tag = create(:tag)
+    login_as(tag.user)
+
+    params = { id: tag.id, tag: { rules: [{ check: 'bar' }] } }
+    patch(:update, params: params)
+
+    expect(tag.reload.rules).to eq([{ check: 'bar' }.stringify_keys])
+  end
+
+  it 'redirects to /tags' do
+    tag = create(:tag)
+    login_as(tag.user)
+
+    params = { id: tag.id, tag: { rules: [{ check: 'bar' }] } }
+    patch(:update, params: params)
+
+    expect(response).to redirect_to('/tags')
+  end
+end

--- a/spec/javascript/tag/action_creators_spec.ts
+++ b/spec/javascript/tag/action_creators_spec.ts
@@ -1,11 +1,9 @@
 jest.mock('src/_helpers/ajax');
 
 import {makeState, makeTag} from '_test_helpers/factories';
-
-import {ajaxPut} from 'src/_helpers/ajax';
 import {
-  SET, UPDATE, UPSERT,
-  setTags, updateTag, upsertTagPlain, upsertTags,
+  SET, UPSERT,
+  setTags, upsertTagPlain, upsertTags,
 } from 'src/tag/action_creators';
 
 describe('setTags', () => {
@@ -13,20 +11,6 @@ describe('setTags', () => {
     const payload = [makeTag()];
 
     expect(setTags(payload)).toEqual({type: SET, payload});
-  });
-});
-
-describe('updateTag', () => {
-  it('returns an update thunk', async () => {
-    const payload: {rules: TagRule[]} = {rules: []};
-    const thunk = updateTag(5, payload);
-    const dispatch = jest.fn();
-    const expectedAction = {type: UPDATE, payload: {id: 5, ...payload}};
-
-    await thunk(dispatch);
-
-    expect(ajaxPut).toHaveBeenCalledWith('/api/v1/tags/5', {tag: payload});
-    expect(dispatch).toHaveBeenCalledWith(expectedAction);
   });
 });
 

--- a/spec/javascript/tag/components/edit_view_spec.tsx
+++ b/spec/javascript/tag/components/edit_view_spec.tsx
@@ -6,13 +6,7 @@ import TagEditView, {Props} from 'src/tag/components/edit_view';
 import {makeTag} from '_test_helpers/factories';
 
 const tag = makeTag();
-type Payload = {rules: TagRule[]};
-const updateTag = jest.fn((id: number, payload: Payload) => Promise.resolve());
-const props: Props = {
-  tag,
-  setRoute: jest.fn(),
-  updateTag,
-};
+const props: Props = {tag};
 const defaultRule = {field: 'estimateSeconds', check: 'isBlank'};
 
 it('renders nothing when tag is not present', () => {
@@ -50,17 +44,4 @@ it('adds rules when "Add Rule" button is clicked', () => {
   expect(addRuleButton).toExist();
   addRuleButton.simulate('click');
   expect(component.find('RuleRow')).toHaveProp('rule', defaultRule);
-});
-
-it('saves the tag on submit', () => {
-  const tempRules = [{field: 'title', check: 'isWobbly'}];
-  const overrides = {...props, tag: {...tag, rules: tempRules}};
-  const component = shallow(<TagEditView {...overrides} />);
-  const preventDefault = jest.fn();
-  const fakeEvent = {preventDefault};
-
-  component.find('form').simulate('submit', fakeEvent);
-
-  expect(preventDefault).toHaveBeenCalled();
-  expect(updateTag).toHaveBeenCalledWith(tag.id, {rules: tempRules});
 });

--- a/spec/javascript/tag/reducer_spec.ts
+++ b/spec/javascript/tag/reducer_spec.ts
@@ -1,4 +1,4 @@
-import {INIT, SET, UPDATE, UPSERT} from 'src/tag/action_creators';
+import {INIT, SET, UPSERT} from 'src/tag/action_creators';
 import tagReducer from 'src/tag/reducer';
 
 import {makeTag, makeTagState} from '_test_helpers/factories';
@@ -20,28 +20,6 @@ describe(SET, () => {
     const expected = {byId: {1: tag1, 5: tag2}};
 
     expect(tagReducer(previousState, action)).toEqual(expected);
-  });
-});
-
-describe(UPDATE, () => {
-  it('throws an error when tag is missing from state', () => {
-    const previousState = {byId: {}};
-    const payload = {id: 1, bloo: 'blargh'};
-    const action = {type: UPDATE, payload};
-    const expectedError = 'no tag found for id 1';
-
-    expect(() => { tagReducer(previousState, action); }).toThrow(expectedError);
-  });
-
-  it('merges into the existing state', () => {
-    const tag1 = makeTag({id: 1, name: 'ber', slug: 'blah'});
-    const tag2 = makeTag({id: 2, name: 'butz'});
-    const previousState = makeTagState({tags: [tag1, tag2]});
-    const payload = {id: 1, name: 'blargh'};
-    const action = {type: UPDATE, payload};
-    const expectedState = {byId: {1: {...tag1, name: 'blargh'}, 2: tag2}};
-
-    expect(tagReducer(previousState, action)).toEqual(expectedState);
   });
 });
 


### PR DESCRIPTION
Rather than updating tags via ajax, this makes the form to update tag
rules a synchronous form submit.
