### PR TITLE
Rubocop: switch Array formats

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,9 @@ AllCops:
 Rails: { Enabled: true }
 
 # ............................................................................ #
+#
 # departures from default
+#
 # ............................................................................ #
 
 # https://github.com/sds/haml-lint/issues/315
@@ -32,12 +34,16 @@ Style/CollectionMethods:
     inject: reduce
     find: detect
     find_all: select
+Style/SymbolArray: { EnforcedStyle: brackets }
 Style/TrailingCommaInArguments: { EnforcedStyleForMultiline: comma }
 Style/TrailingCommaInArrayLiteral: { EnforcedStyleForMultiline: comma }
 Style/TrailingCommaInHashLiteral: { EnforcedStyleForMultiline: comma }
+Style/WordArray: { EnforcedStyle: brackets }
 
 # ............................................................................ #
+#
 # intentionally disabled
+#
 # ............................................................................ #
 
 Bundler/GemComment: { Enabled: false }

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 ruby File.read('./.ruby-version').strip
 
 # needs to be included before any other gems that use environment variables
-gem 'dotenv-rails', groups: %i[development test]
+gem 'dotenv-rails', groups: [:development, :test]
 
 gem 'rails', '~> 7.0.0'
 

--- a/Rakefile
+++ b/Rakefile
@@ -9,5 +9,5 @@ if Rails.env.test? || Rails.env.development?
   require 'haml_lint/rake_task'
   HamlLint::RakeTask.new
 
-  task default: %i[rubocop haml_lint]
+  task default: [:rubocop, :haml_lint]
 end

--- a/app/controllers/api/v1/tags_controller.rb
+++ b/app/controllers/api/v1/tags_controller.rb
@@ -19,7 +19,7 @@ module API
       def tag_params
         params
           .require(:tag)
-          .permit(:name, rules: %i[check field])
+          .permit(:name, rules: [:check, :field])
           .to_h
           .merge(user: current_user)
           .symbolize_keys

--- a/app/controllers/api/v1/tasks_controller.rb
+++ b/app/controllers/api/v1/tasks_controller.rb
@@ -79,15 +79,15 @@ module API
       end
 
       def permitted_params
-        %i[
-          done
-          parent_task_id
-          postpone
-          priority
-          release_at
-          repeat_seconds
-          timeframe
-          title
+        [
+          :done,
+          :parent_task_id,
+          :postpone,
+          :priority,
+          :release_at,
+          :repeat_seconds,
+          :timeframe,
+          :title,
         ]
       end
 

--- a/app/controllers/free_accounts_controller.rb
+++ b/app/controllers/free_accounts_controller.rb
@@ -24,6 +24,6 @@ class FreeAccountsController < ApplicationController
   end
 
   def permitted_params
-    %i[email password password_confirmation]
+    [:email, :password, :password_confirmation]
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -10,7 +10,7 @@ class TagsController < ApplicationController
   def tag_params
     params
       .require(:tag)
-      .permit(rules: %i[check field])
+      .permit(rules: [:check, :field])
       .to_h
       .merge(user: current_user)
       .symbolize_keys

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -33,7 +33,7 @@ class TasksController < ApplicationController
   end
 
   def permitted_params
-    %i[done postpone title priority timeframe]
+    [:done, :postpone, :title, :priority, :timeframe]
   end
 
   def parsed_title

--- a/app/models/stat.rb
+++ b/app/models/stat.rb
@@ -1,7 +1,7 @@
 class Stat < ApplicationRecord
   belongs_to :user
 
-  NAMES = %w[seconds-completed].freeze
+  NAMES = ['seconds-completed'].freeze
 
   validates :user_id, presence: true
   validates :timestamp, uniqueness: { scope: :user_id }

--- a/app/poros/timeframe.rb
+++ b/app/poros/timeframe.rb
@@ -1,5 +1,14 @@
 class Timeframe
-  NAMES = %w[today week month quarter year lustrum decade century].freeze
+  NAMES = [
+    'today',
+    'week',
+    'month',
+    'quarter',
+    'year',
+    'lustrum',
+    'decade',
+    'century',
+  ].freeze
 
   attr_reader :tasks, :name
 

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += %i[passw secret token _key crypt salt certificate otp ssn]
+Rails.application.config.filter_parameters += [:passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,11 @@ Rails.application.routes.draw do
   scope constraints: HtmlConstraint.new do
     root 'pages#index'
 
-    resource :session, only: %i[create destroy]
+    resource :session, only: [:create, :destroy]
 
-    resources :free_accounts, only: %i[new create]
-    resources :charges, only: %i[new create]
-    resources :tags, only: %i[update]
+    resources :free_accounts, only: [:new, :create]
+    resources :charges, only: [:new, :create]
+    resources :tags, only: [:update]
     get '/what', to: 'pages#what'
     get '/privacy', to: 'pages#privacy'
 
@@ -21,14 +21,14 @@ Rails.application.routes.draw do
   scope constraints: JsonConstraint.new do
     namespace :api do
       namespace :v1 do
-        resources :tags, only: %i[create update]
-        resources :tasks, only: %i[index create update destroy]
+        resources :tags, only: [:create, :update]
+        resources :tasks, only: [:index, :create, :update, :destroy]
       end
     end
 
-    resources :tasks, only: %i[index update]
+    resources :tasks, only: [:index, :update]
     resources :timeframes, only: [:index]
-    resource :bulk_task, only: %i[create update]
+    resource :bulk_task, only: [:create, :update]
 
     get '(/:slug)', to: 'tasks#show'
   end

--- a/db/migrate/20130718145023_add_account_id_to_user.rb
+++ b/db/migrate/20130718145023_add_account_id_to_user.rb
@@ -2,7 +2,7 @@ class AddAccountIdToUser < ActiveRecord::Migration
   def change
     add_column :users, :account_id, :integer
     add_column :users, :account_type, :string
-    add_index :users, %i[account_id account_type], unique: true
+    add_index :users, [:account_id, :account_type], unique: true
     add_index :users, :account_type
     add_index :users, :account_id
   end

--- a/db/migrate/20140203015942_add_indices.rb
+++ b/db/migrate/20140203015942_add_indices.rb
@@ -1,6 +1,6 @@
 class AddIndices < ActiveRecord::Migration
   def change
     add_index :quickies, :done_at
-    add_index :taggings, %i[context_id quickie_id]
+    add_index :taggings, [:context_id, :quickie_id]
   end
 end

--- a/db/migrate/20140424043605_remove_indices.rb
+++ b/db/migrate/20140424043605_remove_indices.rb
@@ -7,7 +7,7 @@ class RemoveIndices < ActiveRecord::Migration
     remove_index :quickies, :user_id
 
     remove_index :taggings, :quickie_id
-    remove_index :taggings, %i[context_id quickie_id]
+    remove_index :taggings, [:context_id, :quickie_id]
   end
 
   def down
@@ -18,6 +18,6 @@ class RemoveIndices < ActiveRecord::Migration
     add_index :quickies, :user_id
 
     add_index :taggings, :quickie_id
-    add_index :taggings, %i[context_id quickie_id]
+    add_index :taggings, [:context_id, :quickie_id]
   end
 end

--- a/db/migrate/20140424043905_rename_quickies_to_tasks.rb
+++ b/db/migrate/20140424043905_rename_quickies_to_tasks.rb
@@ -11,7 +11,7 @@ class RenameQuickiesToTasks < ActiveRecord::Migration
     rename_column :taggings, :quickie_id, :task_id
 
     add_index :taggings, :task_id
-    add_index :taggings, %i[context_id task_id], unique: true
+    add_index :taggings, [:context_id, :task_id], unique: true
 
     rename_column :users, :quickies_count, :tasks_count
     rename_column :contexts, :quickies_count, :tasks_count

--- a/db/migrate/20150407145353_null_false_positions.rb
+++ b/db/migrate/20150407145353_null_false_positions.rb
@@ -1,6 +1,6 @@
 class NullFalsePositions < ActiveRecord::Migration
   def change
     change_column_null :tasks, :position, false
-    add_index :tasks, %i[priority position]
+    add_index :tasks, [:priority, :position]
   end
 end

--- a/db/migrate/20160517003354_add_unique_stat_constraint.rb
+++ b/db/migrate/20160517003354_add_unique_stat_constraint.rb
@@ -1,5 +1,5 @@
 class AddUniqueStatConstraint < ActiveRecord::Migration
   def change
-    add_index :stats, %i[name user_id timestamp], unique: true
+    add_index :stats, [:name, :user_id, :timestamp], unique: true
   end
 end

--- a/lib/serializable/locator.rb
+++ b/lib/serializable/locator.rb
@@ -2,15 +2,15 @@ module Serializable
 
   class Locator
     BASE_CLASSES = Set.new(
-      %w[
-        Hash
-        NilClass
-        String
-        Fixnum
-        FalseClass
-        Integer
-        TrueClass
-        ActiveSupport::TimeWithZone
+      [
+        'Hash',
+        'NilClass',
+        'String',
+        'Fixnum',
+        'FalseClass',
+        'Integer',
+        'TrueClass',
+        'ActiveSupport::TimeWithZone',
       ],
     )
 

--- a/lib/serializable/root_serializer.rb
+++ b/lib/serializable/root_serializer.rb
@@ -22,7 +22,7 @@ module Serializable
     private
 
     def validate_options(options)
-      allowed_keys = %i[meta included]
+      allowed_keys = [:meta, :included]
       invalid_keys = options.keys - allowed_keys
       if invalid_keys.any?
         raise "invalid serializer options: #{invalid_keys}, " \

--- a/spec/controllers/api/v1/tasks_controller/update_spec.rb
+++ b/spec/controllers/api/v1/tasks_controller/update_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe API::V1::TasksController, '#update' do
     put(:update, params: valid_params)
     task.reload
     expect(task.title).to eq 'foo'
-    expect(task.tag_names).to eq %w[home]
+    expect(task.tag_names).to eq ['home']
     expect(task.priority).to eq 3
     expect(task.estimate_seconds).to eq 300
   end
@@ -40,7 +40,7 @@ RSpec.describe API::V1::TasksController, '#update' do
     put(:update, params: valid_params)
     task = JSON.parse(response.body)['data']
     expect(task['title']).to eq 'foo'
-    expect(task['tagNames']).to eq %w[home]
+    expect(task['tagNames']).to eq ['home']
     expect(task['priority']).to eq 3
     expect(task['estimateSeconds']).to eq 300
   end

--- a/spec/controllers/tasks_controller/update_spec.rb
+++ b/spec/controllers/tasks_controller/update_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe TasksController, '#update' do
     put(:update, params: valid_params)
     task.reload
     expect(task.title).to eq 'foo'
-    expect(task.tag_names).to eq %w[home]
+    expect(task.tag_names).to eq ['home']
     expect(task.priority).to eq 3
     expect(task.estimate_seconds).to eq 300
   end
@@ -40,7 +40,7 @@ RSpec.describe TasksController, '#update' do
     put(:update, params: valid_params)
     task = JSON.parse(response.body)['data']
     expect(task['title']).to eq 'foo'
-    expect(task['tagNames']).to eq %w[home]
+    expect(task['tagNames']).to eq ['home']
     expect(task['priority']).to eq 3
     expect(task['estimateSeconds']).to eq 300
   end

--- a/spec/domains/task/bulk_create_spec.rb
+++ b/spec/domains/task/bulk_create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Task::BulkCreate do
     expect do
       bulk_task_create.(titles: "*1d eat\n@10pm wax teeth\n#me moo", user: user)
     end.to change(Task, :count).by(3)
-    expect(Task.undone.pluck(:title).sort).to eq %w[eat moo]
+    expect(Task.undone.pluck(:title).sort).to eq ['eat', 'moo']
   end
 
   it 'does not create blank tasks' do

--- a/spec/domains/task/update_spec.rb
+++ b/spec/domains/task/update_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Task::Update do
   let(:task_update_params) do
     {
       title: 'foo',
-      tag_names: %w[home],
+      tag_names: ['home'],
       priority: 3,
       estimate_seconds: 300,
     }
@@ -15,7 +15,7 @@ RSpec.describe Task::Update do
     task_update.(task, task_update_params)
     task.reload
     expect(task.title).to eq 'foo'
-    expect(task.tag_names).to eq %w[home]
+    expect(task.tag_names).to eq ['home']
     expect(task.priority).to eq 3
     expect(task.estimate_seconds).to eq 300
   end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe 'Tasks page', js: true do
     expect(page).to have_selector(repeat_selector)
     task = Task.first
     expect(task.title).to eq 'do laundry'
-    expect(task.tags.pluck(:name).sort).to eq %w[at-home chore]
+    expect(task.tags.pluck(:name).sort).to eq ['at-home', 'chore']
     expect(task.priority).to eq 2
     expect(task.repeat_seconds).to eq 1.week
     # expect(task.repeat_string).to eq 'every week'

--- a/spec/models/task/tag_names_spec.rb
+++ b/spec/models/task/tag_names_spec.rb
@@ -3,12 +3,12 @@ RSpec.describe Task, '#tag_names' do
   let(:tag) { create(:tag, name: 'what') }
 
   it 'returns @tag_names when defined' do
-    task.tag_names = %w[apple pie]
-    expect(task.tag_names).to eq %w[apple pie]
+    task.tag_names = ['apple', 'pie']
+    expect(task.tag_names).to eq ['apple', 'pie']
   end
 
   it 'returns the names of the associated tags when @tag_names not defined' do
     task.tags = [tag]
-    expect(task.tag_names).to eq %w[what]
+    expect(task.tag_names).to eq ['what']
   end
 end

--- a/spec/models/user/absorb_spec.rb
+++ b/spec/models/user/absorb_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe User, '#absorb' do
     )
     create(:tag, name: 'another-solo', user: user)
     tag_2 = create(:tag, name: 'duplicate', user: user)
-    expected_names = %w[another-solo duplicate solo]
+    expected_names = ['another-solo', 'duplicate', 'solo']
     user.absorb(other_user)
     expect(user.reload.tags.pluck(:name).sort).to eq expected_names
     expect(other_task.reload.tags).to eq [tag_2]

--- a/spec/poros/parsers/tag_parser_spec.rb
+++ b/spec/poros/parsers/tag_parser_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe TagParser do
 
   it 'returns an array of tag_names when there are #tags in the string' do
     result = parser.('#at-home take out trash')
-    expect(result).to eq(title: 'take out trash', tag_names: %w[at-home])
+    expect(result).to eq(title: 'take out trash', tag_names: ['at-home'])
     result = parser.('#at-home eat stuff #at-work')
-    expected = { title: 'eat stuff', tag_names: %w[at-home at-work] }
+    expected = { title: 'eat stuff', tag_names: ['at-home', 'at-work'] }
     expect(result).to eq(expected)
   end
 

--- a/spec/poros/parsers/title_parser_spec.rb
+++ b/spec/poros/parsers/title_parser_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TitleParser do
     title = "#at-home take out trash !3 #lame *1w ~5mi @#{time_string}"
     result = parser.(title)
     expect(result[:title]).to eq 'take out trash'
-    expect(result[:tag_names].sort).to eq %w[at-home lame]
+    expect(result[:tag_names].sort).to eq ['at-home', 'lame']
     expect(result[:priority]).to eq 3
     expect(result[:repeat_seconds]).to eq 1.week
     expect(result[:estimate_seconds]).to eq 5.minutes
@@ -22,12 +22,12 @@ RSpec.describe TitleParser do
   it 'returns no keys for missing markers' do
     result = parser.('nothing special')
     expect(result[:title]).to eq 'nothing special'
-    %i[
-      tag_names
-      priority
-      repeat_seconds
-      estimate_seconds
-      release_at
+    [
+      :tag_names,
+      :priority,
+      :repeat_seconds,
+      :estimate_seconds,
+      :release_at,
     ].each do |marker|
       expect(result).not_to have_key(marker)
     end
@@ -35,8 +35,8 @@ RSpec.describe TitleParser do
 
   it 'returns an array of tag_names when there are #tags in the string' do
     result = parser.('#at-home take out trash')
-    expect(result[:tag_names]).to eq %w[at-home]
+    expect(result[:tag_names]).to eq ['at-home']
     result = parser.('#at-home eat stuff #at-work')
-    expect(result[:tag_names].sort).to eq %w[at-home at-work]
+    expect(result[:tag_names].sort).to eq ['at-home', 'at-work']
   end
 end

--- a/spec/serializers/task_serializer/as_json_spec.rb
+++ b/spec/serializers/task_serializer/as_json_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe TaskSerializer, '#as_json' do
       repeat_seconds: 25,
       release_at: 1.week.from_now.round,
       skip_count: 3,
-      tag_names: %w[home work],
+      tag_names: ['home', 'work'],
       title: 'foo task',
       timeframe: 'week',
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ Capybara.javascript_driver = driver
 Capybara.server_port = 8081
 Capybara.save_path = ENV.fetch('CIRCLE_ARTIFACTS', Capybara.save_path)
 
-%i[chrome selenium_chrome selenium_chrome_headless].each do |driver_name|
+[:chrome, :selenium_chrome, :selenium_chrome_headless].each do |driver_name|
   Capybara::Screenshot.register_driver(driver_name) do |capybara_driver, path|
     capybara_driver.browser.save_screenshot(path)
   end


### PR DESCRIPTION
It's a bit longer, but I think consistency is better. It makes grepping
more reliable and reduces potential confusion for different types in
arrays.
