### PR TITLE
NoReact: split routes for React endpoints

### DIFF
--- a/app/controllers/bulk_tasks_controller.rb
+++ b/app/controllers/bulk_tasks_controller.rb
@@ -1,4 +1,8 @@
 class BulkTasksController < ApplicationController
+  def new
+    render html: '', layout: 'react'
+  end
+
   def create
     Task::BulkCreate.(**create_params.symbolize_keys)
     respond_to do |format|

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,7 +1,6 @@
 class PagesController < ApplicationController
-  layout 'react', only: :index
   def index
-    render html: '', layout: true
+    render html: '', layout: 'react'
   end
 
   def what; end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,8 @@
 class SessionsController < ApplicationController
+  def new
+    render html: '', layout: 'react'
+  end
+
   def create
     result = Session::Create.(**session_params, current_user: current_user)
     if result.success?
@@ -6,7 +10,7 @@ class SessionsController < ApplicationController
       return_or_redirect_to root_path, notice: 'Logged in!'
     else
       flash[:error] = 'Invalid email or password'
-      redirect_to '/sessions/new'
+      redirect_to new_session_path
     end
   end
 

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,4 +1,16 @@
 class TagsController < ApplicationController
+  def index
+    render html: '', layout: 'react'
+  end
+
+  def show
+    render html: '', layout: 'react'
+  end
+
+  def edit
+    render html: '', layout: 'react'
+  end
+
   def update
     tag = current_user.tags.find(params[:id])
     Tag::Update.(tag, tag_params)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -4,6 +4,7 @@ class TasksController < ApplicationController
       format.json do
         render json: serialize(current_user.undone_and_pending_tasks)
       end
+      format.html { render html: '', layout: 'react' }
     end
   end
 
@@ -11,6 +12,7 @@ class TasksController < ApplicationController
     task = current_user.next_task(params[:slug])
     respond_to do |format|
       format.json { render json: serialize(task) }
+      format.html { render html: '', layout: 'react' }
     end
   end
 

--- a/app/controllers/timeframes_controller.rb
+++ b/app/controllers/timeframes_controller.rb
@@ -3,6 +3,9 @@ class TimeframesController < ApplicationController
     timeframe = Timeframe.for(user: current_user)
     meta = { medianProductivity: current_user.stats.median_productivity }
 
-    render(json: serialize(timeframe, meta: meta))
+    respond_to do |format|
+      format.json { render(json: serialize(timeframe, meta: meta)) }
+      format.html { render html: '', layout: 'react' }
+    end
   end
 end

--- a/app/javascript/src/route/routes.ts
+++ b/app/javascript/src/route/routes.ts
@@ -36,7 +36,7 @@ const ROUTES = compileRoutes([
   {name: 'root', path: '/'},
   {name: 'bulkTaskNew', path: '/bulk_task/new'},
   {name: 'freeAccountsNew', path: '/free_accounts/new'},
-  {name: 'sessionsNew', path: '/sessions/new'},
+  {name: 'sessionsNew', path: '/session/new'},
   {name: 'sessions', path: '/sessions'},
   {name: 'leafTasks', path: '/tasks/leaf'},
   {name: 'rootTasks', path: '/tasks/root'},

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -25,7 +25,7 @@
               need to
               = link_to 'Sign up', new_free_account_path
               or
-              = link_to 'Log in', '/sessions/new'
+              = link_to 'Log in', new_session_path
             - else
               Logged in as #{current_user.email}
               %br

--- a/app/views/layouts/react.html.haml
+++ b/app/views/layouts/react.html.haml
@@ -25,7 +25,7 @@
               need to
               = link_to 'Sign up', new_free_account_path
               or
-              = link_to 'Log in', '/sessions/new'
+              = link_to 'Log in', new_session_path
             - else
               Logged in as #{current_user.email}
               %br

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,16 +7,17 @@ Rails.application.routes.draw do
   scope constraints: HtmlConstraint.new do
     root 'pages#index'
 
-    resource :session, only: [:create, :destroy]
+    resource :session, only: [:new, :create, :destroy]
 
-    resource :bulk_task, only: [:create]
+    resource :bulk_task, only: [:new, :create]
     resources :free_accounts, only: [:new, :create]
     resources :charges, only: [:new, :create]
-    resources :tags, only: [:update]
+    resources :tags, only: [:index, :update, :edit]
+    resources :tasks, only: [:index, :show]
+    resources :timeframes, only: [:index]
     get '/what', to: 'pages#what'
     get '/privacy', to: 'pages#privacy'
-
-    get '/*path', to: 'pages#index'
+    get '/:slug', to: 'tags#show'
   end
 
   scope constraints: JsonConstraint.new do

--- a/spec/controllers/bulk_tasks_controller/new_spec.rb
+++ b/spec/controllers/bulk_tasks_controller/new_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe BulkTasksController, '#new' do
+  it 'renders the react layout' do
+    get(:new)
+
+    expect(rendered).to have_selector('#app-base')
+  end
+end

--- a/spec/controllers/sessions_controller/create_spec.rb
+++ b/spec/controllers/sessions_controller/create_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe SessionsController, '#create' do
 
     it 'renders the "new" template' do
       post(:create, params: { session: valid_attributes })
-      expect(response).to redirect_to('/sessions/new')
+      expect(response).to redirect_to(new_session_path)
     end
   end
 end

--- a/spec/controllers/sessions_controller/new_spec.rb
+++ b/spec/controllers/sessions_controller/new_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe SessionsController, '#new' do
+  it 'renders the react layout' do
+    get(:new)
+
+    expect(rendered).to have_selector('#app-base')
+  end
+end

--- a/spec/controllers/tags_controller/edit_spec.rb
+++ b/spec/controllers/tags_controller/edit_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe TagsController, '#edit' do
+  it 'renders the react layout' do
+    tag = create(:tag)
+    login_as(tag.user)
+
+    get(:edit, params: { id: tag.id })
+
+    expect(rendered).to have_selector('#app-base')
+  end
+end

--- a/spec/controllers/tags_controller/index_spec.rb
+++ b/spec/controllers/tags_controller/index_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe TagsController, '#index' do
+  it 'renders the react layout' do
+    get(:index)
+
+    expect(rendered).to have_selector('#app-base')
+  end
+end

--- a/spec/controllers/tags_controller/show_spec.rb
+++ b/spec/controllers/tags_controller/show_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe TagsController, '#show' do
+  it 'renders the react layout' do
+    tag = create(:tag)
+    login_as(tag.user)
+
+    get(:show, params: { slug: tag.slug })
+
+    expect(rendered).to have_selector('#app-base')
+  end
+end

--- a/spec/controllers/timeframes_controller/index_spec.rb
+++ b/spec/controllers/timeframes_controller/index_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe TimeframesController, '#index' do
   it 'returns the median productivity for the current user' do
     Stat.create!(stat_params.merge(value: 35.minutes, timestamp: 1.month.ago))
     Stat.create!(stat_params.merge(value: 1.hour, timestamp: 1.week.ago))
-    get(:index)
+    get(:index, format: :json)
     meta = JSON.parse(response.body)['meta']
     expect(meta).to include('medianProductivity' => 1.hour)
     Stat.create!(stat_params.merge(value: 35.minutes, timestamp: 5.days.ago))
-    get(:index)
+    get(:index, format: :json)
     meta = JSON.parse(response.body)['meta']
     expect(meta).to include('medianProductivity' => 2850)
   end
@@ -19,7 +19,7 @@ RSpec.describe TimeframesController, '#index' do
   it 'returns the inbox timeframe for the current user' do
     task = create(:task, user: user)
     serial_task = hash_including('id' => task.id, 'timeframe' => nil)
-    get(:index)
+    get(:index, format: :json)
     timeframes = JSON.parse(response.body)['data']
     expect(timeframes).to include('name' => 'inbox', 'tasks' => [serial_task])
   end
@@ -33,7 +33,7 @@ RSpec.describe TimeframesController, '#index' do
     serial_task_2 = hash_including('id' => task_2.id, 'timeframe' => 'week')
     serial_task_3 = hash_including('id' => task_3.id, 'timeframe' => 'year')
 
-    get(:index)
+    get(:index, format: :json)
 
     timeframes = JSON.parse(response.body)['data']
     expect(timeframes).to include('name' => 'inbox', 'tasks' => [serial_task_1])

--- a/spec/javascript/route/action_creators_spec.ts
+++ b/spec/javascript/route/action_creators_spec.ts
@@ -35,7 +35,7 @@ describe('fetchRoute', () => {
     const payload = {name: 'sessionsNew', params: {}};
     const expectedAction = {type: SET, payload};
 
-    window.history.replaceState(null, '', '/sessions/new');
+    window.history.replaceState(null, '', '/session/new');
 
     expect(fetchRoute()).toEqual(expectedAction);
   });

--- a/spec/javascript/route/helpers_spec.ts
+++ b/spec/javascript/route/helpers_spec.ts
@@ -26,7 +26,7 @@ describe('findRoute', () => {
     const route = findRoute('sessionsNew');
 
     expect(route.name).toBe('sessionsNew');
-    expect(route.toPath()).toBe('/sessions/new');
+    expect(route.toPath()).toBe('/session/new');
   });
 
   it('raises an error when a route cannot be found', () => {
@@ -54,7 +54,7 @@ describe('matchPath', () => {
   });
 
   it('returns a match with a nested route', () => {
-    const match = matchPath('/sessions/new');
+    const match = matchPath('/session/new');
 
     expect(match).toEqual({name: 'sessionsNew', params: {}});
   });

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,7 @@ RSpec.configure do |config|
   config.include(FactoryBot::Syntax::Methods)
   config.include(Questlog::Matchers)
   config.include(Questlog::Wrappers)
+  config.include(ControllerHelpers, type: :controller)
   config.fixture_path = Rails.root.join('spec/fixtures')
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -1,0 +1,6 @@
+module ControllerHelpers
+
+  def rendered
+    Capybara.string(response.body)
+  end
+end


### PR DESCRIPTION
This will make it easier to move individual pages to be server rendered.
