### PR TITLE
Specs: don't wait for flash fade

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -427,7 +427,7 @@ DEPENDENCIES
   bcrypt
   better_errors
   bootsnap
-  bootstrap-sass
+  bootstrap-sass (= 3.4.1)
   capybara
   capybara-screenshot
   dalli

--- a/spec/features/user_account_spec.rb
+++ b/spec/features/user_account_spec.rb
@@ -19,6 +19,5 @@ RSpec.describe 'user accounts', js: true do
     click_button('Login')
     expect(page).to have_content("Logged in as #{user.email}")
     expect(page).to have_content('Logged in!')
-    expect(page).to have_no_content('Logged in!')
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,9 +103,10 @@ end
 
 def add_task(task_title)
   fill_in 'new-title', with: task_title
+  expect(page).to have_field('new-title', with: task_title)
   click_button 'Add Task'
   expect(page).to have_content('Task added')
-  expect(page).not_to have_content('Task added')
+  expect(page).to have_no_field('new-title', with: task_title)
 end
 
 def edit_task(new_title)


### PR DESCRIPTION
Waiting for the flash message to fade really slows down the tests, so
this should make a pretty big difference in build times.
