### PR TITLE
NoReact: remove refresh link

### DIFF
--- a/app/javascript/packs/freeze_time.ts
+++ b/app/javascript/packs/freeze_time.ts
@@ -1,7 +1,6 @@
 import FakeTimers from '@sinonjs/fake-timers';
-import {assert} from 'src/_helpers/assert';
 
-const element = assert(document.querySelector('.time-freeze'));
+const element = document.querySelector('.time-freeze');
 if (element instanceof HTMLElement) {
   const now = Number(element.dataset.timestamp);
   FakeTimers.install({now});

--- a/app/javascript/src/timeframe/components/list_view.tsx
+++ b/app/javascript/src/timeframe/components/list_view.tsx
@@ -1,8 +1,7 @@
 import autobind from 'class-autobind';
-import React, {MouseEvent} from 'react';
+import React from 'react';
 
 import ToEnglish from 'src/_helpers/to_english';
-import TaskStore from 'src/task/store';
 
 import NewTaskForm from 'src/task/containers/new_task_form';
 import TimeframeStore from 'src/timeframe/store';
@@ -102,14 +101,6 @@ class TimeframeListView extends React.Component<Props, State> {
     return timeframes.filter(timeframeHasTasks);
   }
 
-  refresh(event: MouseEvent) {
-    const {fetchTasks} = this.props;
-
-    event.preventDefault();
-    TaskStore.unload();
-    fetchTasks();
-  }
-
   render() {
     const {loading} = this.state;
 
@@ -126,7 +117,6 @@ class TimeframeListView extends React.Component<Props, State> {
         <NewTaskForm />
         <header className='timeframes-header'>
           <h2>{`Median Productivity: ${this.productivityString()} per day`}</h2>
-          <a onClick={this.refresh} href='/timeframes'>{'Refresh'}</a>
         </header>
         {this.renderedTimeframes()}
       </div>

--- a/spec/features/timeframes_spec.rb
+++ b/spec/features/timeframes_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe 'timeframes', js: true do
       expect(page).to have_text('Median Productivity: 35 minutes per day')
     end
 
-    click_link('Refresh')
+    refresh
 
     sidebar.click('FOCUS')
     expect(page).to have_task('clean dishes')
@@ -79,7 +79,7 @@ RSpec.describe 'timeframes', js: true do
     task_1 = create(:task, user: user)
     task_2 = create(:task, user: user, estimate_seconds: 365)
 
-    click_link('Refresh')
+    refresh
 
     expect(page).to have_no_css('.timeframe')
     within('.inbox#inbox') do


### PR DESCRIPTION
The user can just refresh the page via the browser. Also, it appears
what's rendered isn't accurate, so refreshing the browser is better.
