### PR TITLE
Deps: integrate turbo, a11y-dialog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,11 +24,12 @@ gem 'pg'
 gem 'pry-rails'
 gem 'puma'
 gem 'puma_worker_killer'
+gem 'redis'
 gem 'sidekiq'
 gem 'skylight'
 gem 'stimulus-rails'
 gem 'stripe'
-# gem 'turbolinks'
+gem 'turbo-rails'
 gem 'webpacker'
 
 gem 'bootstrap-sass', '3.4.1' # needs dartsass

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,6 +388,9 @@ GEM
     tilt (2.0.10)
     timecop (0.9.5)
     timeout (0.2.0)
+    turbo-rails (1.0.1)
+      actionpack (>= 6.0.0)
+      railties (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     uglifier (4.2.0)
@@ -454,6 +457,7 @@ DEPENDENCIES
   puma_worker_killer
   rails (~> 7.0.0)
   rb-inotify
+  redis
   rspec-rails
   rspec_junit_formatter
   rubocop
@@ -471,6 +475,7 @@ DEPENDENCIES
   stimulus-rails
   stripe
   timecop
+  turbo-rails
   uglifier
   vcr
   web-console

--- a/app/javascript/@types/turbo.d.ts
+++ b/app/javascript/@types/turbo.d.ts
@@ -1,0 +1,11 @@
+declare module '@hotwired/turbo-rails' {
+  type TurboSession = {
+    drive: boolean;
+  }
+
+  type Turbo = {
+    session: TurboSession;
+  }
+
+  export const Turbo: Turbo;
+}

--- a/app/javascript/src/application.tsx
+++ b/app/javascript/src/application.tsx
@@ -2,6 +2,8 @@ import 'src/globals';
 import $ from 'jquery';
 import Honeybadger from 'honeybadger-js';
 import 'controllers/index';
+import {Turbo} from '@hotwired/turbo-rails';
+Turbo.session.drive = false;
 
 $(() => $('[class^=flash-]').fadeOut(1500));
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: [['@babel/preset-env', {targets: {node: 'current'}}]],
+};

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,6 @@
 development:
-  adapter: async
+  adapter: redis
+  url: redis://localhost:6379/1
 
 test:
   adapter: test

--- a/config/jest.json
+++ b/config/jest.json
@@ -36,6 +36,10 @@
   },
   "testEnvironment": "jsdom",
   "transform": {
-    "^.+\\.(ts|tsx)$": "ts-jest"
-  }
+    "^.+\\.(ts|tsx)$": "ts-jest",
+    "^.+\\.js$": "babel-jest"
+  },
+  "transformIgnorePatterns": [
+    "/node_modules/(?!(@hotwired/turbo-rails)/)"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "repository": "https://github.com/mockdeep/questlog",
   "dependencies": {
     "@hotwired/stimulus": "^3.0.1",
+    "@hotwired/turbo-rails": "^7.1.1",
     "@rails/webpacker": "^5.4.3",
     "@types/classnames": "^2.3.1",
     "@types/hoist-non-react-statics": "^3.3.0",
@@ -14,6 +15,7 @@
     "@types/react-modal": "^3.13.1",
     "@types/react-redux": "^7.1.23",
     "@types/react-textarea-autosize": "^4.3.6",
+    "a11y-dialog": "^7.3.0",
     "bootstrap-sass": "3.4.1",
     "class-autobind": "^0.1.4",
     "classnames": "^2.3.1",
@@ -46,7 +48,6 @@
   "//": {
     "bootstrap-sass": "locked at 3.4.1 until dartsass is integrated",
     "later -> @rails/ujs": "^6.0.0-alpha",
-    "later -> turbolinks": "^5.2.0",
     "later -> @rails/activestorage": "^6.0.0-alpha",
     "later -> @rails/actioncable": "^6.0.0-alpha",
     "postcss": "a dep of stylelint-config-standard-scss, can probably be removed later"

--- a/yarn.lock
+++ b/yarn.lock
@@ -955,6 +955,19 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.0.1.tgz#141f15645acaa3b133b7c247cad58ae252ffae85"
   integrity sha512-oHsJhgY2cip+K2ED7vKUNd2P+BEswVhrCYcJ802DSsblJFv7mPFVk3cQKvm2vHgHeDVdnj7oOKrBbzp1u8D+KA==
 
+"@hotwired/turbo-rails@^7.1.1":
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-7.1.1.tgz#35c03b92b5c86f0137ed08bef843d955ec9bbe83"
+  integrity sha512-ZXpxUjCfkdbuXfoGrsFK80qsVzACs8xCfie9rt2jMTSN6o1olXVA0Nrk8u02yNEwSiVJm/4QSOa8cUcMj6VQjg==
+  dependencies:
+    "@hotwired/turbo" "^7.1.0"
+    "@rails/actioncable" "^7.0"
+
+"@hotwired/turbo@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-7.1.0.tgz#27e44e0e3dc5bd1d4bda0766d579cf5a14091cd7"
+  integrity sha512-Q8kGjqwPqER+CtpQudbH+3Zgs2X4zb6pBAlr6NsKTXadg45pAOvxI9i4QpuHbwSzR2+x87HUm+rot9F/Pe8rxA==
+
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
@@ -1258,6 +1271,11 @@
   integrity sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==
   dependencies:
     mkdirp "^1.0.4"
+
+"@rails/actioncable@^7.0":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.2.tgz#69a6d999f4087e0537dd38fe0963db1f4305d650"
+  integrity sha512-G26maXW1Kx0LxQdmNNuNjQlRO/QlXNr3QfuwKiOKb5FZQGYe2OwtHTGXBAjSoiu4dW36XYMT/+L1Wo1Yov4ZXA==
 
 "@rails/webpacker@^5.4.3":
   version "5.4.3"
@@ -1859,6 +1877,13 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
+a11y-dialog@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/a11y-dialog/-/a11y-dialog-7.3.0.tgz#8f5de726ebc8d1e29977ee57cc49a4f2e54bc59f"
+  integrity sha512-xrpSBbOOtGHT+gXcTk9uXfvfFx1xd3LebBhjpjd5xedzeM2FPqNeT6BvLjB+ej8oEH2fCpDHKn5JIlmiNyV5bA==
+  dependencies:
+    focusable-selectors "^0.3.1"
 
 abab@^2.0.0, abab@^2.0.3, abab@^2.0.5:
   version "2.0.5"
@@ -4787,6 +4812,11 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
+
+focusable-selectors@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/focusable-selectors/-/focusable-selectors-0.3.1.tgz#7eacbca8dc6cc8d7f7563e5f5cc3699b91e20aaa"
+  integrity sha512-5JLtr0e1YJIfmnVlpLiG+av07dd0Xkf/KfswsXcei5KmLfdwOysTQsjF058ynXniujb1fvev7nql1x+CkC5ikw==
 
 follow-redirects@^1.0.0:
   version "1.13.0"


### PR DESCRIPTION
Needed to configure `babel-jest` because Turbo uses ES6 modules, which
Jest/node doesn't support out of the box.
