### PR TITLE
NoReact: move js include tags to head

### DIFF
--- a/app/javascript/controllers/react_controller.tsx
+++ b/app/javascript/controllers/react_controller.tsx
@@ -1,4 +1,5 @@
 import {Controller} from '@hotwired/stimulus';
+import Modal from 'react-modal';
 import ReactDOM from 'react-dom';
 
 import appBase from 'src/app_base';
@@ -8,6 +9,8 @@ import {removeNotification} from 'src/notification/action_creators';
 
 class ReactController extends Controller {
   connect() {
+    Modal.setAppElement('#app-base');
+
     window.addEventListener('popstate', () => {
       appStore.dispatch(fetchRoute());
     });

--- a/app/javascript/src/_common/components/alpha_modal.tsx
+++ b/app/javascript/src/_common/components/alpha_modal.tsx
@@ -42,6 +42,4 @@ function AlphaModal({isOpen, closeModal}: Props) {
   );
 }
 
-Modal.setAppElement('#app-base');
-
 export default AlphaModal;

--- a/app/javascript/src/_common/components/help_modal.tsx
+++ b/app/javascript/src/_common/components/help_modal.tsx
@@ -117,6 +117,4 @@ function HelpModal({isOpen, closeModal}: Props) {
   );
 }
 
-Modal.setAppElement('#app-base');
-
 export default HelpModal;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -14,6 +14,10 @@
     /= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = csrf_meta_tags
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }/
+    - if Rails.env.test? && Timecop.frozen?
+      .time-freeze{ data: { timestamp: Time.now.to_i * 1000 } }
+      = javascript_pack_tag 'freeze_time'
+    = javascript_pack_tag 'application'
 
   %body
     - action = 'resize@window->layout#updateScreenSize'
@@ -48,9 +52,3 @@
 
       .footer
         = mail_to('robert@boon.gl', 'Feedback')
-
-    - if Rails.env.test? && Timecop.frozen?
-      .time-freeze{ data: { timestamp: Time.now.to_i * 1000 } }
-      = javascript_pack_tag 'freeze_time'
-
-    = javascript_pack_tag 'application'


### PR DESCRIPTION
Turbo doesn't like being loaded in the body, so this moves the
JavaScript loading to `head`.
