### PR TITLE
CircleCI: lock down yarn version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ commands:
       - node/install:
           node-version: 16.14.0
           install-yarn: true
+          yarn-version: 1.22.16
           install-npm: false
 
       - run:


### PR DESCRIPTION
Seeing [failures on CircleCI][fail] with the latest version of yarn.

[fail]: https://app.circleci.com/pipelines/github/mockdeep/questlog/3607/workflows/e38cd6f8-7c72-4941-abe5-80ed142d2e0e/jobs/16912
