### PR TITLE
Bugs: move freeze time element down

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,13 +13,14 @@
     = stylesheet_link_tag 'application', media: 'all'
     /= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
     = csrf_meta_tags
+    = javascript_pack_tag 'application'
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1.0' }/
+
+  %body
     - if Rails.env.test? && Timecop.frozen?
       .time-freeze{ data: { timestamp: Time.now.to_i * 1000 } }
       = javascript_pack_tag 'freeze_time'
-    = javascript_pack_tag 'application'
 
-  %body
     - action = 'resize@window->layout#updateScreenSize'
     .container.content{ data: { controller: 'layout', action: action } }
       .row


### PR DESCRIPTION
The `head` element cannot have a `div` inside it, so it causes the
browser to expand the `body` up to include it.
