### PR TITLE
Specs: only freeze Date

### DIFF
--- a/app/javascript/packs/freeze_time.ts
+++ b/app/javascript/packs/freeze_time.ts
@@ -3,7 +3,7 @@ import FakeTimers from '@sinonjs/fake-timers';
 const element = document.querySelector('.time-freeze');
 if (element instanceof HTMLElement) {
   const now = Number(element.dataset.timestamp);
-  FakeTimers.install({now});
+  FakeTimers.install({now, toFake: ['Date']});
 } else {
   throw new Error('element is not HTMLElement');
 }


### PR DESCRIPTION
By default FakeTimers fakes a whole bunch of browser APIs, including
`requestAnimationFrame`, which is used heavily by Turbo. When it's
faked, it doesn't call the animation callback until you manually trigger
it via the fake clock. We only really need `Date` currently, as that's
what is used to calculate timeframes.
