### PR TITLE
Deps: move fake-timers out of dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@hotwired/stimulus": "^3.0.1",
     "@hotwired/turbo-rails": "^7.1.1",
     "@rails/webpacker": "^5.4.3",
+    "@sinonjs/fake-timers": "^9.1.1",
     "@types/classnames": "^2.3.1",
     "@types/hoist-non-react-statics": "^3.3.0",
     "@types/jquery": "^3.5.14",
@@ -14,6 +15,7 @@
     "@types/react-dom": "^17.0.13",
     "@types/react-redux": "^7.1.23",
     "@types/react-textarea-autosize": "^4.3.6",
+    "@types/sinonjs__fake-timers": "^8.1.1",
     "a11y-dialog": "^7.3.0",
     "bootstrap-sass": "3.4.1",
     "class-autobind": "^0.1.4",
@@ -51,11 +53,9 @@
     "postcss": "a dep of stylelint-config-standard-scss, can probably be removed later"
   },
   "devDependencies": {
-    "@sinonjs/fake-timers": "^9.1.1",
     "@types/enzyme": "^3.10.11",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^27.4.1",
-    "@types/sinonjs__fake-timers": "^8.1.1",
     "@typescript-eslint/eslint-plugin": "^5.14.0",
     "@typescript-eslint/parser": "^5.14.0",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
This is preventing deploying to production because we have a
`javascript_pack_tag` that depends on it. Kind of gross, but the quick
and dirty solution seems to be to add the dependency to the general
dependencies. Eventually, we should probably find a way to only compile
the pack tag in test mode, but not sure how to make that happen.
