### PR TITLE
NoReact: remove unmount hooks

### DIFF
--- a/app/javascript/src/notification/components/checkbox.tsx
+++ b/app/javascript/src/notification/components/checkbox.tsx
@@ -29,10 +29,6 @@ class NotificationCheckbox extends React.Component<Props, never> {
     }
   }
 
-  componentWillUnmount() {
-    this.closeNotification();
-  }
-
   enableNotifications() {
     const {updateUser} = this.props;
 

--- a/app/javascript/src/task/components/show_view.tsx
+++ b/app/javascript/src/task/components/show_view.tsx
@@ -52,12 +52,6 @@ class TaskShowView extends React.Component<Props, never> {
     this.setTask(task);
   }
 
-  componentWillUnmount() {
-    const {updateTaskMeta} = this.props;
-
-    updateTaskMeta({newTask: {title: ''}});
-  }
-
   setTask(task: Task) {
     if (!task) { return; }
 

--- a/app/javascript/src/timeframe/components/list_view.tsx
+++ b/app/javascript/src/timeframe/components/list_view.tsx
@@ -15,7 +15,6 @@ function timeframeHasTasks(timeframe: Timeframe) {
 
 type Props = {
   deleteTask: Function,
-  fetchTasks: Function,
   updateTask: Function,
 };
 
@@ -26,24 +25,17 @@ type State = {
 };
 
 class TimeframeListView extends React.Component<Props, State> {
-  unsubscribeTimeframes: Callback;
-
   constructor(props: Props) {
     super(props);
     this.state = {timeframes: [], medianProductivity: null, loading: true};
-    this.unsubscribeTimeframes = () => { /* reassigned later */ };
     autobind(this);
   }
 
   componentDidMount() {
     TimeframeStore.getAll().then((data: TimeframeData) => {
       this.updateTimeframes(data);
-      this.unsubscribeTimeframes = TimeframeStore.subscribe(this.loadTasks);
+      TimeframeStore.subscribe(this.loadTasks);
     });
-  }
-
-  componentWillUnmount() {
-    this.unsubscribeTimeframes();
   }
 
   loadTasks() {

--- a/spec/javascript/notification/components/checkbox_spec.tsx
+++ b/spec/javascript/notification/components/checkbox_spec.tsx
@@ -61,11 +61,3 @@ it('notifies on interval when notificationsEnabled changes to true', () => {
 
   expect(notifySpy).toHaveBeenCalled();
 });
-
-it('closes notifications when the component unmounts', () => {
-  const notificationCheckbox = shallow(<NotificationCheckbox {...props} />);
-
-  notificationCheckbox.unmount();
-
-  expect(removeNotification).toHaveBeenCalledWith({key: 'currentTask'});
-});

--- a/spec/javascript/task/components/show_view_spec.tsx
+++ b/spec/javascript/task/components/show_view_spec.tsx
@@ -40,15 +40,6 @@ it('updates the task in meta when component updates', () => {
   expect(updateTaskMeta.mock.calls[1][0].newTask.parentTaskId).toBe(501);
 });
 
-it('clears the task meta space when component unmounts', () => {
-  const task = makeTask({title: 'foo title'});
-  const component = shallow(<TaskShowView {...props} task={task} />);
-
-  component.unmount();
-
-  expect(updateTaskMeta).toHaveBeenLastCalledWith({newTask: {title: ''}});
-});
-
 it('renders something when the task is present', () => {
   const task = makeTask({title: 'foo title'});
 


### PR DESCRIPTION
Since the routes have been separated, these components only unmount on a
full page refresh, so we don't need to have the callbacks.
