### PR TITLE
NoReact: remove task completion from notification

### DIFF
--- a/app/javascript/src/_common/components/task_footer.tsx
+++ b/app/javascript/src/_common/components/task_footer.tsx
@@ -3,14 +3,13 @@ import React from 'react';
 import NotificationCheckbox from 'src/notification/containers/checkbox';
 
 export type Props = {
-  completeTask: Function;
   task?: Task;
 };
 
-function TaskFooter({task, completeTask}: Props) {
+function TaskFooter({task}: Props) {
   return (
     <footer className='task-footer'>
-      {task && <NotificationCheckbox task={task} completeTask={completeTask} />}
+      {task && <NotificationCheckbox task={task} />}
       <br />
       <a href='/bulk_task/new'>{'Add multiple tasks'}</a>
       {' | '}

--- a/app/javascript/src/notification/components/checkbox.tsx
+++ b/app/javascript/src/notification/components/checkbox.tsx
@@ -3,7 +3,6 @@ import React, {ChangeEvent} from 'react';
 
 type Props = {
   addNotification: Function;
-  completeTask: Function;
   notificationsEnabled: boolean;
   removeNotification: Function;
   task: Task;
@@ -51,15 +50,8 @@ class NotificationCheckbox extends React.Component<Props, never> {
     addNotification({
       key: 'currentTask',
       message: task.title,
-      onClick: this.completeTask,
+      onClick: this.closeNotification,
     });
-  }
-
-  completeTask() {
-    const {completeTask, task} = this.props;
-
-    this.closeNotification();
-    completeTask(task.id);
   }
 
   shouldShowNotifications() {

--- a/app/javascript/src/task/components/focus_view.tsx
+++ b/app/javascript/src/task/components/focus_view.tsx
@@ -100,7 +100,7 @@ class TaskFocusView extends React.Component<Props, State> {
         <hr />
         <NewTaskForm />
 
-        <TaskFooter task={task} completeTask={this.completeTask} />
+        <TaskFooter task={task} />
       </div>
     );
   }

--- a/spec/javascript/_common/components/task_footer_spec.tsx
+++ b/spec/javascript/_common/components/task_footer_spec.tsx
@@ -4,7 +4,7 @@ import {shallow} from 'enzyme';
 import {makeTask} from '_test_helpers/factories';
 import TaskFooter, {Props} from 'src/_common/components/task_footer';
 
-const props: Props = {task: makeTask(), completeTask: jest.fn()};
+const props: Props = {task: makeTask()};
 
 it('renders the notification checkbox', () => {
   const component = shallow(<TaskFooter {...props} />);


### PR DESCRIPTION
Doesn't make so much sense to me now. Not sure of the click behavior,
but we might want to remove all of it if we can instead focus the window
on click.
