### PR TITLE
CircleCI: switch to Firefox for feature specs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,13 +117,13 @@ jobs:
       - store_test_results: # https://circleci.com/docs/2.0/collect-test-data/
           path: test_results
 
-  feature_tests_chrome:
+  feature_tests:
     executor: ruby_image
     steps:
       - setup_environment
       - run:
-          name: Run feature tests on Chrome
-          command: COVERAGE=false DRIVER=chrome bundle exec rspec spec/features
+          name: Run feature tests
+          command: COVERAGE=false bundle exec rspec spec/features
 
 workflows:
   version: 2
@@ -132,4 +132,4 @@ workflows:
       - lints
       - javascript_tests
       - unit_tests
-      - feature_tests_chrome
+      - feature_tests

--- a/app/views/layouts/_sidebar.html.haml
+++ b/app/views/layouts/_sidebar.html.haml
@@ -5,12 +5,15 @@
     %button.sidebar__toggle.sidebar__toggle--visible{ data: data }
       %i.fas.fa-bars
   %hr.sidebar__divider/
-  = sidebar_link_to(root_path) do
-    %h2 FOCUS
-  = sidebar_link_to(tasks_path) do
-    %h2 ALL TASKS
-  = sidebar_link_to(timeframes_path) do
-    %h2 TIMEFRAMES
+  %h2
+    = sidebar_link_to(root_path) do
+      FOCUS
+  %h2
+    = sidebar_link_to(tasks_path) do
+      ALL TASKS
+  %h2
+    = sidebar_link_to(timeframes_path) do
+      TIMEFRAMES
 
 .sidebar.sidebar--hidden.hide-me{ data: { layout_target: 'collapsedSidebar' } }
   - data = { action: 'layout#showSidebar' }

--- a/spec/features/sub_tasks_spec.rb
+++ b/spec/features/sub_tasks_spec.rb
@@ -74,16 +74,4 @@ RSpec.describe 'adding sub tasks', js: true do
     expect(page).to have_no_task('the sub task')
     expect(page).to have_no_task('the sub sub task')
   end
-
-  it 'does not have side effects on adding tasks on other pages' do
-    add_task('the parent task')
-    find('.task-link').click
-    expect(page).to have_task('the parent task')
-    add_task('the sub task')
-    expect(task_row('the sub task')).to be_truthy
-    visit(root_path)
-    add_task('!1 the not sub task')
-    find('.task-link').click
-    expect(page).to have_no_link('the parent task')
-  end
 end


### PR DESCRIPTION
Chrome has been super flaky, so hopefully Firefox will be better.

For some reason the Firefox driver didn't like having a heading inside
of a link, so I made it a link inside of a heading and that worked.

I also needed to change the way that I edited tasks, as it was oddly
submitting a blank task.
