### PR TITLE
NoReact: simplify timeframe TaskRow

### DIFF
--- a/app/javascript/src/timeframe/components/section.tsx
+++ b/app/javascript/src/timeframe/components/section.tsx
@@ -26,7 +26,6 @@ class TimeframeSection extends React.Component<Props, never> {
 
     return (
       <TaskRow
-        timeframesEnabled
         timeframeSpace={timeframeSpace}
         task={task}
         key={task.id}
@@ -42,7 +41,6 @@ class TimeframeSection extends React.Component<Props, never> {
     return (
       <TaskRow
         status='pending'
-        timeframesEnabled
         timeframeSpace={timeframeSpace}
         task={task}
         key={task.id}

--- a/app/javascript/src/timeframe/components/task_row.tsx
+++ b/app/javascript/src/timeframe/components/task_row.tsx
@@ -8,7 +8,6 @@ import grab from 'src/_helpers/grab';
 import TaskEditIcon from 'src/task/components/edit_icon';
 import TaskEditTitleForm from 'src/task/components/edit_title_form';
 import timeframeNameMap from 'src/timeframe/name_map';
-import {assert} from 'src/_helpers/assert';
 import type {UpdateTask} from 'src/task/action_creators';
 
 const BUTTON_CLASS = 'btn btn-link tasks-table__action';
@@ -17,10 +16,8 @@ export type Props = {
   deleteTask: (taskId: number) => void,
   task: Task,
   updateTask: UpdateTask,
-  isDragging?: boolean,
   status?: string,
-  timeframesEnabled?: boolean,
-  timeframeSpace?: TimeframeSpace,
+  timeframeSpace: TimeframeSpace,
 };
 
 type State = {
@@ -74,13 +71,12 @@ class TaskRow extends React.PureComponent<Props, State> {
   }
 
   className() {
-    const {isDragging, status} = this.props;
+    const {status} = this.props;
 
     return classnames({
       'tasks-table__row': true,
       [`tasks-table__row--priority-${this.priority()}`]: this.priority(),
       [`tasks-table__row--${status}`]: status,
-      'tasks-table__row--dragging': isDragging,
     });
   }
 
@@ -99,12 +95,12 @@ class TaskRow extends React.PureComponent<Props, State> {
   timeframeHasSpace(name: string) {
     const {task, timeframeSpace} = this.props;
 
-    return grab(assert(timeframeSpace), name) >= task.estimateMinutes;
+    return grab(timeframeSpace, name) >= task.estimateMinutes;
   }
 
   optionText(title: string, name: string) {
     const {timeframeSpace} = this.props;
-    const space = grab(assert(timeframeSpace), name);
+    const space = grab(timeframeSpace, name);
     let text = title;
 
     if (this.timeframe() !== name && isFinite(space)) {
@@ -184,7 +180,7 @@ class TaskRow extends React.PureComponent<Props, State> {
   }
 
   render() {
-    const {task, timeframesEnabled} = this.props;
+    const {task} = this.props;
 
     return (
       <tr className={this.className()} ref={this.storeDOMNode}>
@@ -206,7 +202,7 @@ class TaskRow extends React.PureComponent<Props, State> {
           </select>
         </td>
         <td>
-          {timeframesEnabled ? this.timeframeSelector() : ''}
+          {this.timeframeSelector()}
         </td>
         <td>
           {task.pending ? this.undoButton() : ''}

--- a/spec/javascript/timeframe/components/task_row_spec.tsx
+++ b/spec/javascript/timeframe/components/task_row_spec.tsx
@@ -10,6 +10,7 @@ const props: Props = {
   deleteTask: jest.fn(),
   updateTask: jest.fn(),
   task: makeTask(),
+  timeframeSpace: {},
 };
 
 it('renders a table row', () => {
@@ -18,8 +19,8 @@ it('renders a table row', () => {
   expect(component.find('tr')).toHaveClassName('tasks-table__row');
 });
 
-it('renders the timeframe selector when enabled', () => {
-  const component = shallow(<TaskRow {...props} timeframesEnabled />);
+it('renders the timeframe selector', () => {
+  const component = shallow(<TaskRow {...props} />);
 
   expect(component.find('select.timeframe-select')).toExist();
 });


### PR DESCRIPTION
This removes properties that are no longer necessary and makes others
required, since they will always be passed in this context.
