### PR TITLE
Deps: remove custom spring ref

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,8 +42,7 @@ group :development do
   gem 'listen'
   gem 'spring'
   gem 'spring-commands-rspec'
-  # https://github.com/rails/spring-watcher-listen/issues/27
-  gem 'spring-watcher-listen', github: 'rails/spring-watcher-listen'
+  gem 'spring-watcher-listen'
   gem 'web-console'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/rails/spring-watcher-listen.git
-  revision: 1f2a7dadaea1089efe815e181c532bb51a6e268a
-  specs:
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 4)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -372,6 +364,9 @@ GEM
     spring (4.1.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
+    spring-watcher-listen (2.1.0)
+      listen (>= 2.7, < 4.0)
+      spring (>= 4)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -474,7 +469,7 @@ DEPENDENCIES
   skylight
   spring
   spring-commands-rspec
-  spring-watcher-listen!
+  spring-watcher-listen
   stimulus-rails
   stripe
   timecop


### PR DESCRIPTION
This seems to broken at the moment for some reason. Eventually, I'm
planning on removing spring anyway, so seems fine to go back to the
released version.
