### PR TITLE
Deps: lock down version of enzyme types

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "postcss": "a dep of stylelint-config-standard-scss, can probably be removed later"
   },
   "devDependencies": {
-    "@types/enzyme": "^3.10.12",
+    "@types/enzyme": "3.10.12",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/jest": "^29.5.0",
     "@typescript-eslint/eslint-plugin": "^5.57.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,7 +1576,7 @@
   dependencies:
     "@types/enzyme" "*"
 
-"@types/enzyme@*", "@types/enzyme@^3.10.12":
+"@types/enzyme@*", "@types/enzyme@3.10.12":
   version "3.10.12"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.12.tgz#ac4494801b38188935580642f772ad18f72c132f"
   integrity sha512-xryQlOEIe1TduDWAOphR0ihfebKFSWOXpIsk+70JskCfRfW+xALdnJ0r1ZOTo85F9Qsjk6vtlU7edTYHbls9tA==


### PR DESCRIPTION
The next point release breaks types pretty bad.
