### PR TITLE
Move request type to headers

### DIFF
--- a/app/javascript/@types/reqwest.d.ts
+++ b/app/javascript/@types/reqwest.d.ts
@@ -3,9 +3,12 @@ type SuccessCallback = (result: any) => void;
 
 declare module 'reqwest' {
   export type BaseRequestOptions = {
-    type: 'json';
     method: RequestMethod;
-    headers: {'X-CSRF-Token': string};
+    headers: {
+      Accept: 'application/json';
+      'X-CSRF-Token': string;
+      'Content-Type': 'application/json';
+    };
     success: SuccessCallback;
     error: ErrorCallback;
   };

--- a/app/javascript/src/_helpers/request.ts
+++ b/app/javascript/src/_helpers/request.ts
@@ -19,9 +19,12 @@ function logError(error: DOMException): void {
 
 function defaultRequestOptions(): BaseRequestOptions {
   return {
-    type: 'json',
     method: 'put',
-    headers: {'X-CSRF-Token': authenticityToken()},
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': authenticityToken(),
+    },
     success: reloadPage,
     error: logError,
   };


### PR DESCRIPTION
This helps make the params more like the `fetch` api.
